### PR TITLE
Returns quiz_id in response of create_quiz POST request

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -288,6 +288,19 @@ class QuizResponse(Quiz):
         }
 
 
+class QuizCreationResponse(BaseModel):
+    """Model for the response of a request that creates a quiz"""
+
+    quiz_id: str
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "quiz_id": "1234",
+            }
+        }
+
+
 class SessionAnswer(BaseModel):
     """Model for the body of the request that creates a session answer"""
 
@@ -341,7 +354,7 @@ class Session(BaseModel):
 class UpdateSession(BaseModel):
     """Model for the body of the request that updates a session"""
 
-    has_quiz_ended: bool = False
+    has_quiz_ended: bool
 
     class Config:
         schema_extra = {

--- a/app/models.py
+++ b/app/models.py
@@ -224,7 +224,7 @@ class Quiz(BaseModel):
         }
 
 
-class QuizResponse(Quiz):
+class GetQuizResponse(Quiz):
     """Model for the response of any request that returns a quiz"""
 
     class Config:
@@ -288,7 +288,7 @@ class QuizResponse(Quiz):
         }
 
 
-class QuizCreationResponse(BaseModel):
+class CreateQuizResponse(BaseModel):
     """Model for the response of a request that creates a quiz"""
 
     quiz_id: str

--- a/app/models.py
+++ b/app/models.py
@@ -291,12 +291,12 @@ class GetQuizResponse(Quiz):
 class CreateQuizResponse(BaseModel):
     """Model for the response of a request that creates a quiz"""
 
-    quiz_id: str
+    id: str
 
     class Config:
         schema_extra = {
             "example": {
-                "quiz_id": "1234",
+                "id": "1234",
             }
         }
 

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -21,7 +21,7 @@ async def create_quiz(quiz: Quiz):
         client.quiz.questions.insert_many(questions)
 
     return JSONResponse(
-        status_code=status.HTTP_201_CREATED, content={"quiz_id": new_quiz.inserted_id}
+        status_code=status.HTTP_201_CREATED, content={"id": new_quiz.inserted_id}
     )
 
 

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -2,12 +2,12 @@ from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from database import client
-from models import Quiz, QuizResponse, QuizCreationResponse
+from models import Quiz, GetQuizResponse, CreateQuizResponse
 
 router = APIRouter(prefix="/quiz", tags=["Quiz"])
 
 
-@router.post("/", response_model=QuizCreationResponse)
+@router.post("/", response_model=CreateQuizResponse)
 async def create_quiz(quiz: Quiz):
     quiz = jsonable_encoder(quiz)
     new_quiz = client.quiz.quizzes.insert_one(quiz)
@@ -20,12 +20,12 @@ async def create_quiz(quiz: Quiz):
 
         client.quiz.questions.insert_many(questions)
 
-    response_content = {"quiz_id": new_quiz.inserted_id}
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED, content={"quiz_id": new_quiz.inserted_id}
+    )
 
-    return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_content)
 
-
-@router.get("/{quiz_id}", response_model=QuizResponse)
+@router.get("/{quiz_id}", response_model=GetQuizResponse)
 async def get_quiz(quiz_id: str):
     if (quiz := client.quiz.quizzes.find_one({"_id": quiz_id})) is not None:
         return quiz

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -2,14 +2,13 @@ from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from database import client
-from models import Quiz, QuizResponse
+from models import Quiz, QuizResponse, QuizCreationResponse
 
 router = APIRouter(prefix="/quiz", tags=["Quiz"])
 
 
-@router.post("/")
+@router.post("/", response_model=QuizCreationResponse)
 async def create_quiz(quiz: Quiz):
-    """Returns the ID of created quiz in a dictionary with key as 'quiz_id'"""
     quiz = jsonable_encoder(quiz)
     new_quiz = client.quiz.quizzes.insert_one(quiz)
     created_quiz = client.quiz.quizzes.find_one({"_id": new_quiz.inserted_id})
@@ -21,9 +20,9 @@ async def create_quiz(quiz: Quiz):
 
         client.quiz.questions.insert_many(questions)
 
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED, content={"quiz_id": new_quiz.inserted_id}
-    )
+    response_content = {"quiz_id": new_quiz.inserted_id}
+
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_content)
 
 
 @router.get("/{quiz_id}", response_model=QuizResponse)

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -7,8 +7,9 @@ from models import Quiz, QuizResponse
 router = APIRouter(prefix="/quiz", tags=["Quiz"])
 
 
-@router.post("/", response_model=QuizResponse)
+@router.post("/")
 async def create_quiz(quiz: Quiz):
+    """Returns the ID of created quiz in a dictionary with key as 'quiz_id'"""
     quiz = jsonable_encoder(quiz)
     new_quiz = client.quiz.quizzes.insert_one(quiz)
     created_quiz = client.quiz.quizzes.find_one({"_id": new_quiz.inserted_id})
@@ -20,7 +21,9 @@ async def create_quiz(quiz: Quiz):
 
         client.quiz.questions.insert_many(questions)
 
-    return JSONResponse(status_code=status.HTTP_201_CREATED, content=created_quiz)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED, content={"quiz_id": new_quiz.inserted_id}
+    )
 
 
 @router.get("/{quiz_id}", response_model=QuizResponse)

--- a/app/tests/base.py
+++ b/app/tests/base.py
@@ -22,7 +22,7 @@ class BaseTestCase(unittest.TestCase):
         # create a question is through the quiz endpoint which is why we are using the quiz endpoint
         # to create questions and a quiz
         response = self.client.post(quizzes.router.prefix + "/", json=self.quiz_data)
-        self.quiz_id = json.loads(response.content)["quiz_id"]
+        self.quiz_id = json.loads(response.content)["id"]
         self.quiz = self.client.get(quizzes.router.prefix + f"/{self.quiz_id}").json()
 
 

--- a/app/tests/base.py
+++ b/app/tests/base.py
@@ -22,7 +22,8 @@ class BaseTestCase(unittest.TestCase):
         # create a question is through the quiz endpoint which is why we are using the quiz endpoint
         # to create questions and a quiz
         response = self.client.post(quizzes.router.prefix + "/", json=self.quiz_data)
-        self.quiz = json.loads(response.content)
+        self.quiz_id = json.loads(response.content)["quiz_id"]
+        self.quiz = self.client.get(quizzes.router.prefix + f"/{self.quiz_id}").json()
 
 
 class SessionsBaseTestCase(BaseTestCase):

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -15,8 +15,8 @@ class QuizTestCase(BaseTestCase):
     def test_create_quiz(self):
         response = self.client.post(quizzes.router.prefix + "/", json=self.quiz_data)
         response = json.loads(response.content)
-        id = response["quiz_id"]
-        response = self.client.get(f"{quizzes.router.prefix}/{id}")
+        quiz_id = response["id"]
+        response = self.client.get(f"{quizzes.router.prefix}/{quiz_id}")
         assert response.status_code == 200
 
     def test_get_question_if_id_valid(self):

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -9,10 +9,13 @@ class QuizTestCase(BaseTestCase):
         self.id = self.quiz["_id"]
         self.length = len(self.quiz_data["question_sets"][0]["questions"])
 
+    def test_setup_quizId_and_quiz(self):
+        assert self.quiz_id == self.quiz["_id"]
+
     def test_create_quiz(self):
         response = self.client.post(quizzes.router.prefix + "/", json=self.quiz_data)
         response = json.loads(response.content)
-        id = response["_id"]
+        id = response["quiz_id"]
         response = self.client.get(f"{quizzes.router.prefix}/{id}")
         assert response.status_code == 200
 

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -9,7 +9,7 @@ class QuizTestCase(BaseTestCase):
         self.id = self.quiz["_id"]
         self.length = len(self.quiz_data["question_sets"][0]["questions"])
 
-    def test_setup_quizId_and_quiz(self):
+    def test_base_setup_quizId_and_quiz(self):
         assert self.quiz_id == self.quiz["_id"]
 
     def test_create_quiz(self):

--- a/app/tests/test_sessions.py
+++ b/app/tests/test_sessions.py
@@ -46,15 +46,16 @@ class SessionsTestCase(SessionsBaseTestCase):
         data = open("app/tests/dummy_data/homework_quiz.json")
         quiz_data = json.load(data)
         response = self.client.post(quizzes.router.prefix + "/", json=quiz_data)
-        quiz = json.loads(response.content)
+        quiz_id = json.loads(response.content)["quiz_id"]
+        quiz = self.client.get(quizzes.router.prefix + f"/{quiz_id}").json()
         response = self.client.post(
             sessions.router.prefix + "/", json={"quiz_id": quiz["_id"], "user_id": 1}
         )
         assert response.status_code == 201
         session = json.loads(response.content)
         assert session["is_first"] is True
-        assert len(session["session_answers"]) == len(
-            quiz_data["question_sets"][0]["questions"]
+        assert len(session["session_answers"]) == sum(
+            len(qset["questions"]) for qset in quiz_data["question_sets"]
         )
 
     def test_create_session_with_valid_quiz_id_and_previous_session(self):

--- a/app/tests/test_sessions.py
+++ b/app/tests/test_sessions.py
@@ -46,7 +46,7 @@ class SessionsTestCase(SessionsBaseTestCase):
         data = open("app/tests/dummy_data/homework_quiz.json")
         quiz_data = json.load(data)
         response = self.client.post(quizzes.router.prefix + "/", json=quiz_data)
-        quiz_id = json.loads(response.content)["quiz_id"]
+        quiz_id = json.loads(response.content)["id"]
         quiz = self.client.get(quizzes.router.prefix + f"/{quiz_id}").json()
         response = self.client.post(
             sessions.router.prefix + "/", json={"quiz_id": quiz["_id"], "user_id": 1}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/quiz-backend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/quiz-backend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://peps.python.org/pep-0008/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #55 

## Summary
- Motivation: Returns only the `quiz_id` instead of the entire created quiz. This reduces load on network. 
- Created quiz can be retrieved by sending a GET request at `/quiz/{quiz_id}` endpoint
- Changes are also made in corresponding `app/tests` files


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
