### PR TITLE
adds Gzipmiddleware to compress JSON responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from routers import questions, quizzes, session_answers, sessions, organizations
 from mangum import Mangum
 
@@ -16,6 +17,11 @@ app.add_middleware(
     allow_origins=origins,
     allow_methods=["*"],
     allow_headers=["*"],
+)
+
+app.add_middleware(
+    GZipMiddleware,
+    minimum_size=100, # if more than 100 bytes, compress
 )
 
 app.include_router(questions.router)

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 from routers import questions, quizzes, session_answers, sessions, organizations
 from mangum import Mangum
 
-COMPRESS_MIN_THRESHOLD = 100  # if more than 100 bytes, compress
+COMPRESS_MIN_THRESHOLD = 1000  # if more than 1000 bytes (~1KB), compress
 
 app = FastAPI()
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,8 @@ from fastapi.middleware.gzip import GZipMiddleware
 from routers import questions, quizzes, session_answers, sessions, organizations
 from mangum import Mangum
 
+COMPRESS_MIN_THRESHOLD = 100  # if more than 100 bytes, compress
+
 app = FastAPI()
 
 origins = [
@@ -21,7 +23,7 @@ app.add_middleware(
 
 app.add_middleware(
     GZipMiddleware,
-    minimum_size=100, # if more than 100 bytes, compress
+    minimum_size=COMPRESS_MIN_THRESHOLD,
 )
 
 app.include_router(questions.router)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/quiz-backend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/quiz-backend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://peps.python.org/pep-0008/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #58 
-- Adds GzipMiddleware to app, this ensures that all responses that are greater than a threshold (100kb currently) are compressed. Such as large quizresponse (all questions and their properties), sessionresponse (all answers and their properites). 

To test -->
You can download the json response body to see that it is approx 720kb, whereas the content-length is 370kb. QuizID to test (on staging) = `62bbae6906dad649f55ff6ff`
<img width="620" alt="image" src="https://user-images.githubusercontent.com/21237473/178214810-cd40577c-930c-4d84-bb99-1f0e6f036bef.png">


## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
