### PR TITLE
timer updates

### DIFF
--- a/app/routers/sessions.py
+++ b/app/routers/sessions.py
@@ -145,6 +145,8 @@ async def update_session(session_id: str, session_updates: UpdateSession):
     * start button is clicked (start-quiz event)
     * resume button is clicked (resume-quiz event)
     * end button is clicked (end-quiz event)
+
+    * dummy event logic added for JNV -- will be removed!
     """
     new_event = jsonable_encoder(session_updates)["event"]
     session = client.quiz.sessions.find_one({"_id": session_id})
@@ -162,17 +164,48 @@ async def update_session(session_id: str, session_updates: UpdateSession):
 
     # diff between times of last two events
     time_elapsed = 0
-    if new_event != EventType.start_quiz:
+    if new_event not in [EventType.start_quiz, EventType.dummy_event]:
         # time_elapsed = 0 for start-quiz event
         if len(session["events"]) >= 2:
             # [sanity check] ensure atleast two events have occured before computing elapsed time
-            time_elapsed = (
-                str_to_datetime(session["events"][-1]["created_at"])
-                - str_to_datetime(session["events"][-2]["created_at"])
-            ).seconds
+            # time_elapsed = (
+            #     str_to_datetime(session["events"][-1]["created_at"])
+            #     - str_to_datetime(session["events"][-2]["created_at"])
+            # ).seconds
+
+            # only for jnv enable -- remove later!
+            # subtract times of last dummy event and last non dummy event
+            dummy_found = False
+            last_dummy_event, last_non_dummy_event = None, None
+            for ev in session["events"][::-1]:
+                if not dummy_found and ev["event_type"] == EventType.dummy_event:
+                    last_dummy_event = ev
+                    dummy_found = True
+                    continue
+
+                if dummy_found and ev["event_type"] != EventType.dummy_event:
+                    last_non_dummy_event = ev
+                    break
+
+            if dummy_found:
+                time_elapsed = (
+                    str_to_datetime(last_dummy_event["created_at"])
+                    - str_to_datetime(last_non_dummy_event["created_at"])
+                ).seconds
+            else:
+                # if no dummy event at all!
+                time_elapsed = (
+                    str_to_datetime(session["events"][-1]["created_at"])
+                    - str_to_datetime(session["events"][-2]["created_at"])
+                ).seconds
 
     response_content = {}
-    if "time_remaining" in session and session["time_remaining"] is not None:
+    # added check for dummy event; dont update time_remaining for it
+    if (
+        new_event != EventType.dummy_event
+        and "time_remaining" in session
+        and session["time_remaining"] is not None
+    ):
         # if `time_remaining` key is not present =>
         # no time limit is set, no need to respond with time_remaining
         session["time_remaining"] = max(0, session["time_remaining"] - time_elapsed)

--- a/app/routers/sessions.py
+++ b/app/routers/sessions.py
@@ -182,7 +182,7 @@ async def update_session(session_id: str, session_updates: UpdateSession):
                     last_dummy_event = ev
                     dummy_found = True
                     continue
-                
+
                 if not dummy_found and ev["event_type"] != EventType.dummy_event:
                     # two quick non-dummy events, ignore -- remove this after JNV enable!
                     break

--- a/app/routers/sessions.py
+++ b/app/routers/sessions.py
@@ -177,11 +177,15 @@ async def update_session(session_id: str, session_updates: UpdateSession):
             # subtract times of last dummy event and last non dummy event
             dummy_found = False
             last_dummy_event, last_non_dummy_event = None, None
-            for ev in session["events"][::-1]:
+            for ev in session["events"][::-1][1:]:
                 if not dummy_found and ev["event_type"] == EventType.dummy_event:
                     last_dummy_event = ev
                     dummy_found = True
                     continue
+                
+                if not dummy_found and ev["event_type"] != EventType.dummy_event:
+                    # two quick non-dummy events, ignore -- remove this after JNV enable!
+                    break
 
                 if dummy_found and ev["event_type"] != EventType.dummy_event:
                     last_non_dummy_event = ev

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -45,3 +45,4 @@ class EventType(str, Enum):
     start_quiz = "start-quiz"
     resume_quiz = "resume-quiz"
     end_quiz = "end-quiz"
+    dummy_event = "dummy-event"


### PR DESCRIPTION
1. Changes made to timer so that we can pause when there is loss of network connection at JNV site.
2. Idea is to poll -- send a dummy event to backend every 8 seconds
3. If there is loss of network -- the time spent by user in taking the test (time elapsed wrt backend logic) is approximately equal to the time between (time of last dummy event creation) and (time of last non-dummy event creation [like a start-quiz event]).

Preferably revert this one-time change. 

