### PR TITLE
Adds question set level marking scheme

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -164,7 +164,9 @@ class QuestionSet(BaseModel):
     questions: List[Question]
     title: Optional[str] = None
     max_questions_allowed_to_attempt: int
-    marking_scheme: MarkingScheme  # takes precedence over question-level marking scheme
+    marking_scheme: MarkingScheme = (
+        None  # takes precedence over question-level marking scheme
+    )
 
 
 class QuestionSetResponse(QuestionSet):

--- a/app/models.py
+++ b/app/models.py
@@ -164,7 +164,7 @@ class QuestionSet(BaseModel):
     questions: List[Question]
     title: Optional[str] = None
     max_questions_allowed_to_attempt: int
-    marking_scheme: MarkingScheme
+    marking_scheme: MarkingScheme  # takes precedence over question-level marking scheme
 
 
 class QuestionSetResponse(QuestionSet):

--- a/app/models.py
+++ b/app/models.py
@@ -164,6 +164,7 @@ class QuestionSet(BaseModel):
     questions: List[Question]
     title: Optional[str] = None
     max_questions_allowed_to_attempt: int
+    marking_scheme: MarkingScheme
 
 
 class QuestionSetResponse(QuestionSet):

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -24,7 +24,10 @@ def update_quiz_for_backwards_compatibility(quiz_collection, quiz_id, quiz):
             )
             question_set["title"] = "Section A"
 
-        if "marking_scheme" not in question_set:
+        if (
+            "marking_scheme" not in question_set
+            or question_set["marking_scheme"] is None
+        ):
             question_marking_scheme = question_set["questions"][0]["marking_scheme"]
             if question_marking_scheme is not None:
                 question_set["marking_scheme"] = question_marking_scheme

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -13,7 +13,7 @@ def update_quiz_for_backwards_compatibility(quiz_collection, quiz_id, quiz):
     """
     if given quiz contains question sets that do not have max_questions_allowed_to_attempt key,
     update the question sets (in-place) with the key and value as len(questions) in that set.
-    Additionally, add a default title for the set
+    Additionally, add a default title and marking scheme for the set.
     Finally, add quiz to quiz_collection
     (NOTE: this is a primitive form of versioning)
     """
@@ -23,6 +23,17 @@ def update_quiz_for_backwards_compatibility(quiz_collection, quiz_id, quiz):
                 question_set["questions"]
             )
             question_set["title"] = "Section A"
+
+        if "marking_scheme" not in question_set:
+            question_marking_scheme = question_set["questions"][0]["marking_scheme"]
+            if question_marking_scheme is not None:
+                question_set["marking_scheme"] = question_marking_scheme
+            else:
+                question_set["marking_scheme"] = {
+                    "correct": 1,
+                    "wrong": 0,
+                    "skipped": 0,
+                }  # default
 
     quiz_collection.update_one({"_id": quiz_id}, {"$set": quiz})
 


### PR DESCRIPTION
Solves #80 

For services that rely on marking schemes (ETL flows, score computations, reporting), question-set level marking scheme takes precedence over question-level marking scheme (if provided).
- Having a question-set level marking scheme makes it easy to update metrics at a question-set level instead of question level. 
- For question sets that have optional questions, we can collect all questions that have been answered by the student (at most `max_questions_allowed_to_attempt`), and multiply marks provided via `marking_scheme`

Note: currently, question-set level marking scheme is required by default. 
