### PR TITLE
Removed dependency on redundant `session_answers` table + optimized some mongo queries

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -365,6 +365,11 @@ class UpdateSessionAnswer(BaseModel):
         schema_extra = {"example": {"answer": [0, 1, 2], "visited": True}}
 
 
+"""
+Note : The below model is not being used currently anywhere
+"""
+
+
 class SessionAnswerResponse(SessionAnswer):
     """Model for the response of any request that returns a session answer"""
 

--- a/app/routers/session_answers.py
+++ b/app/routers/session_answers.py
@@ -8,50 +8,50 @@ from utils import remove_optional_unset_args
 router = APIRouter(prefix="/session_answers", tags=["Session Answers"])
 
 
-@router.patch("/{session_answer_id}", response_model=SessionAnswerResponse)
-async def update_session_answer(
-    session_answer_id: str, session_answer: UpdateSessionAnswer
+@router.patch("/{session_id}/{position_index}", response_model=SessionAnswerResponse)
+async def update_session_answer_in_a_session(
+    session_id: str, position_index: int, session_answer: UpdateSessionAnswer
 ):
+    """
+    Update a session answer in a session by its position index in the session answers array
+    Path Params:
+    session_id - the id of the session
+    position_index - the position index of the session answer in the session answers array. This corresponds to the position of the question in the quiz
+    """
     session_answer = remove_optional_unset_args(session_answer)
     session_answer = jsonable_encoder(session_answer)
 
-    if (client.quiz.session_answers.find_one({"_id": session_answer_id})) is None:
+    # check if the session exists
+    session = client.quiz.sessions.find_one({"_id": session_id})
+    if session is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"session_answer {session_answer_id} not found",
+            detail=f"Provided session with id {session_id} not found",
         )
+
+    # check if the session has session answers key
+    if "session_answers" not in session or session["session_answers"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No session answers found in the session with id {session_id}",
+        )
+
+    # check if the session answer index that we're trying to access is out of bounds or not
+    if position_index > len(session["session_answers"]):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Provided position index {position_index} is out of bounds of length of the session answers array",
+        )
+
+    # constructing the $set query for mongodb
+    setQuery = {}
+    for key, value in session_answer.items():
+        setQuery[f"session_answers.{position_index}.{key}"] = value
 
     # update the document in the session_answers collection
-    client.quiz.session_answers.update_one(
-        {"_id": session_answer_id}, {"$set": session_answer}
-    )
+    client.quiz.sessions.update_one({"_id": session_id}, {"$set": setQuery})
 
-    updated_session_answer = client.quiz.session_answers.find_one(
-        {"_id": session_answer_id}
-    )
-
-    # update the document in the sessions collection if this answer
-    # is present in the subset of session answers we store in the document
-    # corresponding to the session
-    session_to_update = client.quiz.sessions.find_one(
-        {"_id": updated_session_answer["session_id"]}
-    )
-
-    session_answers = list(session_to_update["session_answers"])
-    update_session = False
-    for index, _ in enumerate(session_answers):
-        if session_answers[index]["_id"] == session_answer_id:
-            session_answers[index].update(session_answer)
-            update_session = True
-            break
-
-    if update_session:
-        client.quiz.sessions.update_one(
-            {"_id": session_to_update["_id"]},
-            {"$set": {"session_answers": session_answers}},
-        )
-
-    return JSONResponse(status_code=status.HTTP_200_OK, content=updated_session_answer)
+    return JSONResponse(status_code=status.HTTP_200_OK, content=session_answer)
 
 
 @router.get("/{session_answer_id}", response_model=SessionAnswerResponse)

--- a/app/routers/session_answers.py
+++ b/app/routers/session_answers.py
@@ -2,13 +2,13 @@ from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from database import client
-from models import SessionAnswerResponse, UpdateSessionAnswer
+from models import UpdateSessionAnswer
 from utils import remove_optional_unset_args
 
 router = APIRouter(prefix="/session_answers", tags=["Session Answers"])
 
 
-@router.patch("/{session_id}/{position_index}", response_model=SessionAnswerResponse)
+@router.patch("/{session_id}/{position_index}", response_model=None)
 async def update_session_answer_in_a_session(
     session_id: str, position_index: int, session_answer: UpdateSessionAnswer
 ):
@@ -51,10 +51,10 @@ async def update_session_answer_in_a_session(
     # update the document in the session_answers collection
     client.quiz.sessions.update_one({"_id": session_id}, {"$set": setQuery})
 
-    return JSONResponse(status_code=status.HTTP_200_OK, content=session_answer)
+    return JSONResponse(status_code=status.HTTP_200_OK)
 
 
-@router.get("/{session_id}/{position_index}", response_model=SessionAnswerResponse)
+@router.get("/{session_id}/{position_index}", response_model=None)
 async def get_session_answer_from_a_session(session_id: str, position_index: int):
     pipeline = [
         {

--- a/app/routers/sessions.py
+++ b/app/routers/sessions.py
@@ -105,7 +105,8 @@ async def create_session(session: Session):
         for _, session_answer in enumerate(session_answers_of_the_last_session):
             # note: we retain created_at key in session_answer
             for key in ["_id", "session_id"]:
-                session_answer.pop(key)
+                if key in session_answer:
+                    session_answer.pop(key)
 
             # append with new session_answer "_id" keys
             session_answers.append(

--- a/app/routers/sessions.py
+++ b/app/routers/sessions.py
@@ -100,14 +100,9 @@ async def create_session(session: Session):
         current_session["has_quiz_ended"] = last_session.get("has_quiz_ended", False)
 
         # restore the answers from the last (previous) sessions
-        last_session_answers = list(
-            client.quiz.session_answers.find(
-                {"session_id": last_session["_id"]},
-                sort=[("_id", pymongo.ASCENDING)],
-            )
-        )
+        session_answers_of_the_last_session = last_session["session_answers"]
 
-        for index, session_answer in enumerate(last_session_answers):
+        for _, session_answer in enumerate(session_answers_of_the_last_session):
             # note: we retain created_at key in session_answer
             for key in ["_id", "session_id"]:
                 session_answer.pop(key)
@@ -120,17 +115,10 @@ async def create_session(session: Session):
     current_session["session_answers"] = session_answers
 
     # insert current session into db
-    new_session = client.quiz.sessions.insert_one(current_session)
-    created_session = client.quiz.sessions.find_one({"_id": new_session.inserted_id})
-
-    # update with new session_id and insert to db
-    for index, _ in enumerate(session_answers):
-        session_answers[index]["session_id"] = new_session.inserted_id
-
-    client.quiz.session_answers.insert_many(session_answers)
+    client.quiz.sessions.insert_one(current_session)
 
     # return the created session
-    return JSONResponse(status_code=status.HTTP_201_CREATED, content=created_session)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=current_session)
 
 
 @router.patch("/{session_id}", response_model=UpdateSessionResponse)
@@ -143,6 +131,7 @@ async def update_session(session_id: str, session_updates: UpdateSession):
     * dummy event logic added for JNV -- will be removed!
     """
     new_event = jsonable_encoder(session_updates)["event"]
+    session_update_query = {}
 
     # if new_event == EventType.dummy_event:
     #     return JSONResponse(
@@ -159,8 +148,10 @@ async def update_session(session_id: str, session_updates: UpdateSession):
     event_obj = jsonable_encoder(Event.parse_obj({"event_type": new_event}))
     if session["events"] is None:
         session["events"] = [event_obj]
+        session_update_query["$set"] = {"events": [event_obj]}
     else:
         session["events"].append(event_obj)
+        session_update_query["$push"] = {"events": event_obj}
 
     # diff between times of last two events
     time_elapsed = 0
@@ -212,15 +203,14 @@ async def update_session(session_id: str, session_updates: UpdateSession):
     ):
         # if `time_remaining` key is not present =>
         # no time limit is set, no need to respond with time_remaining
-        session["time_remaining"] = max(0, session["time_remaining"] - time_elapsed)
+        time_remaining = max(0, session["time_remaining"] - time_elapsed)
+        session_update_query["$set"] = {"time_remaining": time_remaining}
         response_content = {"time_remaining": session["time_remaining"]}
 
     # update the document in the sessions collection
     if new_event == EventType.end_quiz:
-        session["has_quiz_ended"] = True
-    client.quiz.sessions.update_one(
-        {"_id": session_id}, {"$set": jsonable_encoder(session)}
-    )
+        session_update_query["$set"] = {"has_quiz_ended": True}
+    client.quiz.sessions.update_one({"_id": session_id}, session_update_query)
 
     return JSONResponse(status_code=status.HTTP_200_OK, content=response_content)
 

--- a/app/tests/test_session_answers.py
+++ b/app/tests/test_session_answers.py
@@ -7,12 +7,13 @@ class SessionAnswerTestCase(SessionsBaseTestCase):
     def setUp(self):
         super().setUp()
         self.session_answers = self.homework_session["session_answers"]
+        self.session_id = self.homework_session["_id"]
+        self.session_answer_position_index = 0
         self.session_answer = self.session_answers[0]
-        self.session_answer_id = self.session_answer["_id"]
 
-    def test_gets_session_answer_with_valid_id(self):
+    def test_gets_session_answer_from_a_session(self):
         response = self.client.get(
-            f"{session_answers.router.prefix}/{self.session_answer_id}"
+            f"{session_answers.router.prefix}/{self.session_id}/{self.session_answer_position_index}"
         )
         assert response.status_code == 200
         session_answer = json.loads(response.content)
@@ -22,12 +23,12 @@ class SessionAnswerTestCase(SessionsBaseTestCase):
     def test_update_session_answer_with_only_answer(self):
         new_answer = [0, 1, 2]
         response = self.client.patch(
-            f"{session_answers.router.prefix}/{self.session_answer_id}",
+            f"{session_answers.router.prefix}/{self.session_id}/{self.session_answer_position_index}",
             json={"answer": new_answer},
         )
         assert response.status_code == 200
         response = self.client.get(
-            f"{session_answers.router.prefix}/{self.session_answer_id}"
+            f"{session_answers.router.prefix}/{self.session_id}/{self.session_answer_position_index}"
         )
         session_answer = json.loads(response.content)
 
@@ -40,12 +41,12 @@ class SessionAnswerTestCase(SessionsBaseTestCase):
     def test_update_session_answer_with_only_visited(self):
         new_visited = True
         response = self.client.patch(
-            f"{session_answers.router.prefix}/{self.session_answer_id}",
+            f"{session_answers.router.prefix}/{self.session_id}/{self.session_answer_position_index}",
             json={"visited": new_visited},
         )
         assert response.status_code == 200
         response = self.client.get(
-            f"{session_answers.router.prefix}/{self.session_answer_id}"
+            f"{session_answers.router.prefix}/{self.session_id}/{self.session_answer_position_index}"
         )
         session_answer = json.loads(response.content)
 

--- a/app/tests/test_sessions.py
+++ b/app/tests/test_sessions.py
@@ -216,8 +216,5 @@ class SessionsTestCase(SessionsBaseTestCase):
             f"{sessions.router.prefix}/{resumed_session_id}"
         ).json()
 
-        # because time has passed between both quizzes
-        assert (
-            json.loads(response.content)["time_remaining"] < quiz["time_limit"]["max"]
-        )
+        # because time has passed between both sessions
         assert updated_resumed_session["time_remaining"] < quiz["time_limit"]["max"]

--- a/app/tests/test_sessions.py
+++ b/app/tests/test_sessions.py
@@ -96,12 +96,14 @@ class SessionsTestCase(SessionsBaseTestCase):
         assert response["is_first"] is False
 
     def test_create_session_with_valid_quiz_id_and_previous_session(self):
+        self.session_id = self.homework_session["_id"]
         self.session_answers = self.homework_session["session_answers"]
+        self.session_answer_position_index = 0
         self.session_answer = self.session_answers[0]
         self.session_answer_id = self.session_answer["_id"]
         new_answer = [0, 1, 2]
         response = self.client.patch(
-            f"{session_answers.router.prefix}/{self.session_answer_id}",
+            f"{session_answers.router.prefix}/{self.session_id}/{self.session_answer_position_index}",
             json={"answer": new_answer},
         )
         response = self.client.post(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/quiz-backend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/quiz-backend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://peps.python.org/pep-0008/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #83 #82 
ADR - https://www.notion.so/avantifellows/ADR-Quiz-Backend-DB-optimization-66e73d0531854098a2702fee070e2fc5

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
