### PR TITLE
Adds Chapter and Topic ID to Question Metadata

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -64,7 +64,9 @@ class QuestionMetadata(BaseModel):
     grade: Optional[str]
     subject: Optional[str]
     chapter: Optional[str]
+    chapter_id: Optional[str]
     topic: Optional[str]
+    topic_id: Optional[str]
     competency: Optional[List[str]]
     difficulty: Optional[str]
 


### PR DESCRIPTION
Adds `chapter_id` and `topic_id` fields to Question Metadata in `models.py` . Simple additions to aid in chapter tagging and question-level analysis. Related ADR: https://www.notion.so/avantifellows/ADR-Chapter-Tagging-Updates-c8a977f5ef874830bedf940927546d2d