### PR TITLE
Update all session answers at once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r app/requirements.txt
-          pip install pytest pytest-cov --rcfile=.coveragerc
+          pip install pytest pytest-cov
 
       - name: Run Test Cases
         # command to run tests and generate coverage metrics
         run: |
-          coverage run -m pytest --rcfile=.coveragerc
+          coverage run --rcfile=.coveragerc -m pytest
           coverage xml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run Test Cases
         # command to run tests and generate coverage metrics
         run: |
-          coverage run -m pytest
+          coverage run -m pytest --rcfile=.coveragerc
           coverage xml
 
       - name: Upload coverage to Codecov

--- a/app/routers/session_answers.py
+++ b/app/routers/session_answers.py
@@ -149,11 +149,11 @@ async def update_all_session_answers_in_a_session(
     result = client.quiz.sessions.update_one({"_id": session_id}, {"$set": setQuery})
     if result.modified_count == 0:
         logger.error(
-            f"Failed to update session answers for session: {session_id} (user: {user_id} and quiz: {quiz_id})"
+            f"Failed to update all session answers for session: {session_id} (user: {user_id} and quiz: {quiz_id})"
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to update session answers for session: {session_id}",
+            detail=f"Failed to update all session answers for session: {session_id}",
         )
 
     logger.info(

--- a/app/routers/session_answers.py
+++ b/app/routers/session_answers.py
@@ -132,11 +132,11 @@ async def update_all_session_answers_in_a_session(
     # check if session_answers array in session that we're trying to update is equal to input_session_answers array length
     if len(input_session_answers) != len(session["session_answers"]):
         logger.error(
-            f"Provided input_session_answers array length not equal to length of array in session in db"
+            "Provided input_session_answers array length not equal to length of array in session in db"
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Provided input_session_answers array length not equal to length of array in session in db",
+            detail="Provided input_session_answers array length not equal to length of array in session in db",
         )
 
     # constructing the $set query for mongodb

--- a/app/routers/session_answers.py
+++ b/app/routers/session_answers.py
@@ -5,6 +5,7 @@ from database import client
 from models import UpdateSessionAnswer
 from utils import remove_optional_unset_args
 from logger_config import get_logger
+from typing import List
 
 router = APIRouter(prefix="/session_answers", tags=["Session Answers"])
 logger = get_logger()
@@ -79,6 +80,84 @@ async def update_session_answer_in_a_session(
 
     logger.info(
         f"Updated session answer for session: {session_id} (user: {user_id} and quiz: {quiz_id}), position: {position_index}"
+    )
+    return JSONResponse(status_code=status.HTTP_200_OK, content=None)
+
+
+@router.patch("/{session_id}", response_model=None)
+async def update_all_session_answers_in_a_session(
+    session_id: str, session_answers: List[UpdateSessionAnswer]
+):
+    """
+    Update all session answers in a session in the session answers array
+    Path Params:
+    session_id - the id of the session
+
+    function params:
+    session_answers - list of session answers for the session
+    """
+    log_message = f"Updating all session answers for session: {session_id}"
+    input_session_answers = [
+        jsonable_encoder(remove_optional_unset_args(session_answer))
+        for session_answer in session_answers
+    ]
+
+    # check if the session exists
+    session = client.quiz.sessions.find_one({"_id": session_id})
+    if session is None:
+        logger.error(
+            f"Received all session_answer update request, but provided session with id {session_id} not found"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Received all session_answer update request, but provided session with id {session_id} not found",
+        )
+
+    # get user_id and quiz_id for logging
+    # Note: every session must have these keys
+    user_id, quiz_id = session["user_id"], session["quiz_id"]
+    log_message += f"(user: {user_id}, quiz: {quiz_id})"
+    logger.info(log_message)
+
+    # check if the session has session answers key
+    if "session_answers" not in session or session["session_answers"] is None:
+        logger.error(
+            f"No session answers found in the session with id {session_id}, for user: {user_id} and quiz: {quiz_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No session answers found in the session with id {session_id}",
+        )
+
+    # check if session_answers array in session that we're trying to update is equal to input_session_answers array length
+    if len(input_session_answers) != len(session["session_answers"]):
+        logger.error(
+            f"Provided input_session_answers array length not equal to length of array in session in db"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Provided input_session_answers array length not equal to length of array in session in db",
+        )
+
+    # constructing the $set query for mongodb
+    setQuery = {}
+    for position_index, session_answer in enumerate(input_session_answers):
+        for key, value in session_answer.items():
+            setQuery[f"session_answers.{position_index}.{key}"] = value
+
+    # update the document in the session_answers collection
+    result = client.quiz.sessions.update_one({"_id": session_id}, {"$set": setQuery})
+    if result.modified_count == 0:
+        logger.error(
+            f"Failed to update session answers for session: {session_id} (user: {user_id} and quiz: {quiz_id})"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update session answers for session: {session_id}",
+        )
+
+    logger.info(
+        f"Updated all session answers for session: {session_id} (user: {user_id} and quiz: {quiz_id})"
     )
     return JSONResponse(status_code=status.HTTP_200_OK, content=None)
 

--- a/app/tests/test_session_answers.py
+++ b/app/tests/test_session_answers.py
@@ -55,3 +55,27 @@ class SessionAnswerTestCase(SessionsBaseTestCase):
 
         # ensure that `answer` is not affected
         assert session_answer["answer"] == self.session_answer["answer"]
+
+    def test_update_all_session_answers(self):
+        new_answers = [{"answer": [0, 2]}] * len(self.session_answers)
+
+        response = self.client.patch(
+            f"{session_answers.router.prefix}/{self.session_id}",
+            json=new_answers,
+        )
+        assert response.status_code == 200
+
+        for session_answer_position_index, answer_obj in enumerate(new_answers):
+            response = self.client.get(
+                f"{session_answers.router.prefix}/{self.session_id}/{session_answer_position_index}"
+            )
+            session_answer = json.loads(response.content)
+
+            # ensure that `answer` has been updated
+            assert session_answer["answer"] == answer_obj["answer"]
+
+            # ensure that `visited` is not affected
+            assert (
+                session_answer["visited"]
+                == self.session_answers[session_answer_position_index]["visited"]
+            )


### PR DESCRIPTION
When a patch request with only `session_id` is provided to `session_answers` route, assert that json body contains all session answers, and update all session answers at once in db. 

This helps in syncing all session answers from frontend before test ends (especially for OMR format in low network areas). 

One test added in `test_session_answers.py`

Solves #99 

Related ADR: https://www.notion.so/avantifellows/ADR-Wait-for-Session-Answer-Response-ce48a939beb240a5b56f5c6035c53931