### PR TITLE
Adds key to check whether reviewing answers is allowed

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -91,6 +91,7 @@ class QuizMetadata(BaseModel):
     topic: Optional[str]
     source: Optional[str]
     source_id: Optional[str]
+    session_end_time: Optional[str]
 
 
 class Question(BaseModel):
@@ -199,6 +200,7 @@ class Quiz(BaseModel):
     shuffle: bool = False
     num_attempts_allowed: int = 1
     time_limit: Optional[QuizTimeLimit] = None
+    always_review_answers: Optional[bool] = True
     navigation_mode: NavigationMode = "linear"
     instructions: Optional[str] = None
     language: QuizLanguage = "en"

--- a/app/models.py
+++ b/app/models.py
@@ -91,7 +91,7 @@ class QuizMetadata(BaseModel):
     topic: Optional[str]
     source: Optional[str]
     source_id: Optional[str]
-    session_end_time: Optional[str]
+    session_end_time: Optional[str]  # format: %Y-%m-%d %I:%M:%S %p
 
 
 class Question(BaseModel):


### PR DESCRIPTION
Currently, once the quiz ends, we always display answers.
Some assessments may prefer not displaying answers immediately and waiting for a while. 
This initial PR adds facility to block display of answers.

- adds two keys: (1) `always_review_answers` - when `true`, correct answers are always displayed; when `false`, frontend makes additional checks to determine whether answers are to be displayed or not. (2) `session_end_time` in quiz metadata

Related ADR: https://www.notion.so/avantifellows/ADR-Session-End-Time-In-Quiz-DB-99d9e6868f7343a18cfb343e916216ec