### PR TITLE
Added session answer delay based on review_delay from quiz model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict
 from bson import ObjectId
 from pydantic import BaseModel, Field
 from schemas import (
@@ -234,6 +234,7 @@ class Quiz(BaseModel):
     time_limit: Optional[QuizTimeLimit] = None
     # review answers immediately after quiz ends
     review_immediate: Optional[bool] = True
+    review_delay: Optional[Dict[str, int]] = Field(default=None, description="Delay in {days, hours, minutes}")
     display_solution: Optional[bool] = True
     show_scores: Optional[bool] = True
     navigation_mode: NavigationMode = "linear"
@@ -298,6 +299,8 @@ class Quiz(BaseModel):
                 "title": "hello world",
                 "max_marks": 10,
                 "num_graded_questions": 3,
+                "review_immediate": False,
+                "review_delay":{"days": 2, "hours": 4, "minutes": 30},
                 "metadata": {
                     "quiz_type": "homework",
                     "subject": "Maths",

--- a/app/routers/session_answers.py
+++ b/app/routers/session_answers.py
@@ -6,6 +6,7 @@ from models import UpdateSessionAnswer
 from utils import remove_optional_unset_args
 from logger_config import get_logger
 from typing import List, Tuple
+from datetime import datetime, timedelta
 
 router = APIRouter(prefix="/session_answers", tags=["Session Answers"])
 logger = get_logger()
@@ -159,6 +160,42 @@ async def get_session_answer_from_a_session(session_id: str, position_index: int
     logger.info(
         f"Getting session answer for session: {session_id}, position: {position_index}"
     )
+    
+    session_data = client["quiz"].sessions.find_one({"_id": session_id}, {"quiz_id": 1, "created_at": 1})
+    if not session_data or "quiz_id" not in session_data:
+        logger.error(f"Quiz ID not found for session {session_id}")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz ID not found")
+
+    quiz_id = session_data["quiz_id"]
+    quiz_data = client["quiz"]["quizzes"].find_one({"_id": quiz_id}, {"review_delay": 1})
+
+    if not quiz_data or "review_delay" not in quiz_data:
+        logger.error(f"Review delay not found for session {session_id}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Review delay not found")
+    
+    review_delay = quiz_data.get("review_delay", {})
+    delay_days = review_delay.get("days", 0)
+    delay_hours = review_delay.get("hours", 0)
+    delay_minutes = review_delay.get("minutes", 0)
+    
+    # Calculate the release time
+    created_at = session_data.get("created_at")
+    if not created_at:
+        logger.error(f"Session {session_id} does not have a creation timestamp")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Session data missing creation time")
+    
+    created_at = datetime.fromisoformat(created_at)  # Ensure this format matches the stored format
+    release_time = created_at + timedelta(days=delay_days, hours=delay_hours, minutes=delay_minutes)
+    
+    # Check if answer can be released
+    current_time = datetime.utcnow()
+    if current_time < release_time:
+        time_remaining = release_time - current_time
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={"message": "Answer not available yet", "time_remaining": str(time_remaining)}
+        )
+    
     pipeline = [
         {
             "$match": {  # match the session with the provided session_id
@@ -174,7 +211,7 @@ async def get_session_answer_from_a_session(session_id: str, position_index: int
             }
         },
     ]
-    aggregation_result = list(client.quiz.sessions.aggregate(pipeline))
+    aggregation_result = list(client["quiz"].sessions.aggregate(pipeline))
     if len(aggregation_result) == 0:
         logger.error(
             f"Either session_id {session_id} is wrong or position_index {position_index} is out of bounds"
@@ -188,5 +225,5 @@ async def get_session_answer_from_a_session(session_id: str, position_index: int
         f"Retrieved session answer for session: {session_id}, position: {position_index}"
     )
     return JSONResponse(
-        status_code=status.HTTP_200_OK, content=aggregation_result[0]["session_answer"]
+        status_code=status.HTTP_200_OK, content=aggregation_result[0]["session_answer"]["answer"]
     )

--- a/app/tests/dummy_data/matrix_matching_assessment.json
+++ b/app/tests/dummy_data/matrix_matching_assessment.json
@@ -1304,7 +1304,8 @@
         "max": 3600
     },
     "shuffle": false,
-    "review_immediate": true,
+    "review_immediate": false,
+    "review_delay":{"days": 0, "hours": 0, "minutes": 5},
     "show_scores": true,
     "metadata": {
         "quiz_type": "assessment",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/quiz-backend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/quiz-backend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://peps.python.org/pep-0008/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #105 

## Summary

This PR implements a delay in accessing session answers based on the review_delay fetched from the quiz model given by quiz creator.

## Motivation

Previously, session answers were accessible immediately. This update ensures that answers are only available after the specified delay (days, hours, minutes).

## Changes Made

Fetch review_delay from the quiz model.

Calculate release_time using created_at + review_delay.

Restrict access to answers until release_time is reached.

Return a 403 Forbidden response if accessed early, along with the remaining time.

Handle cases where review_delay is missing gracefully.

Before the delay time
![Screenshot 2025-03-28 203314](https://github.com/user-attachments/assets/b3f18a4b-4502-4127-8775-733f536eabbd)

After delay time
![Screenshot 2025-03-28 203829](https://github.com/user-attachments/assets/8dabd359-2575-46b4-90c8-a2215a376d43)




<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
