### PR TITLE
Add checks to ensure that multiple devices do not use the same quiz a…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "python.analysis.autoImportCompletions": true,
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./app",
+        "-p",
+        "*test.py"
+    ],
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestArgs": [
+        "app"
+    ]
+}


### PR DESCRIPTION
This PR addresses a critical concurrency issue where multiple devices or parallel requests could create multiple active sessions for the same user and quiz combination. Issue#103

What’s Changed:

- Atomic Upsert Logic for Session Creation:
- Replaced the naive insert logic with an atomic update_one operation using upsert=True and $setOnInsert.
- Ensures a session is only created once for a given (user_id, quiz_id, created_at) combination, avoiding race conditions.
- Robust Logging and Error Handling:
- Added clear logging to differentiate between already existing sessions, successful new session creation, and failure scenarios.
- 

Test Coverage:

- Introduced a concurrent session creation test using Python’s ThreadPoolExecutor.
- Simulates 10 parallel requests attempting to create the same session.
- Asserts that only one unique session is created, validating the atomic behavior.
