### PR TITLE
Remove ECS CPU autoscaling policies

### DIFF
--- a/terraform/prod/autoscaling.tf
+++ b/terraform/prod/autoscaling.tf
@@ -9,18 +9,3 @@ resource "aws_appautoscaling_target" "ecs" {
     ignore_changes = [min_capacity, max_capacity]
   }
 }
-
-resource "aws_appautoscaling_policy" "cpu" {
-  name               = "quiz-backend-${var.environment}-cpu"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.ecs.resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
-
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
-    }
-    target_value = 50
-  }
-}

--- a/terraform/testing/autoscaling.tf
+++ b/terraform/testing/autoscaling.tf
@@ -9,18 +9,3 @@ resource "aws_appautoscaling_target" "ecs" {
     ignore_changes = [min_capacity, max_capacity]
   }
 }
-
-resource "aws_appautoscaling_policy" "cpu" {
-  name               = "quiz-backend-${var.environment}-cpu"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.ecs.resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
-
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
-    }
-    target_value = 50
-  }
-}


### PR DESCRIPTION
## Summary

- Removes the `aws_appautoscaling_policy.cpu` resource from both testing and prod Terraform configs
- The `quiz_scale_scheduler` flow in etl-next now fully controls ECS task counts (min, max, desired) via the Google Sheet schedule
- The CPU target-tracking policies were conflicting by overriding the desired count the flow sets (e.g., flow sets desired=3, policy pulls it back to 2 due to low CPU)
- The `aws_appautoscaling_target` resource is kept so the flow can continue setting min/max capacity bounds

## Important

After merging, you need to run `terraform apply` in both `terraform/testing/` and `terraform/prod/` to actually delete the policies from AWS.

## Test plan

- [ ] `terraform plan` in testing shows only the policy removal (no other drift)
- [ ] `terraform plan` in prod shows only the policy removal
- [ ] After apply: verify policies are gone with `aws application-autoscaling describe-scaling-policies`
- [ ] Trigger quiz_scale_scheduler flow and confirm desired count stays at what the flow sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)