### PR TITLE
OMR Projection Now Order-Proof: Map by question_set_id, Not Position (Closes #148)

### DIFF
--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -12,6 +12,42 @@ settings = Settings()
 logger = get_logger()
 
 
+def project_omr_option_counts(question_sets, aggregated_results, subset_size):
+    """
+    Project option placeholders for OMR mode using deterministic question_set_id mapping.
+    """
+    results_by_qs_id = {}
+    for result in aggregated_results:
+        qset_id = result.get("question_set_id")
+        if qset_id in results_by_qs_id:
+            raise ValueError("Duplicate question_set_id detected in aggregated results")
+        results_by_qs_id[qset_id] = result
+
+    for question_set in question_sets:
+        qset_id = question_set.get("_id")
+        result = results_by_qs_id.get(qset_id)
+        if not result:
+            continue
+
+        options_count_per_set = result.get("options_count_per_set") or []
+        updated_subset_without_details = []
+        for question_index, question in enumerate(question_set.get("questions") or []):
+            if question_index < subset_size:
+                continue
+
+            if question_index >= len(options_count_per_set):
+                updated_subset_without_details.append(question)
+                continue
+
+            # options_count will be zero for subjective/numerical questions.
+            question["options"] = [{"text": "", "image": None}] * options_count_per_set[
+                question_index
+            ]
+            updated_subset_without_details.append(question)
+
+        question_set["questions"][subset_size:] = updated_subset_without_details
+
+
 def _hide_answers_in_quiz_in_place(quiz: dict) -> None:
     """
     Hide answers/solutions from base quiz endpoint.
@@ -250,29 +286,19 @@ async def get_quiz(
                             "options_count_per_set": {"$push": "$number_of_options"},
                         }
                     },
-                    {"$sort": {"_id": 1}},  # sort sets based on question_set_id
-                    {"$project": {"_id": 0, "options_count_per_set": 1}},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "question_set_id": "$_id",
+                            "options_count_per_set": 1,
+                        }
+                    },
                 ]
             )
         )
-        for question_set_index, question_set in enumerate(quiz["question_sets"]):
-            updated_subset_without_details = []
-            options_count_per_set = options_count_across_sets[question_set_index][
-                "options_count_per_set"
-            ]
-            for question_index, question in enumerate(question_set["questions"]):
-                if question_index < settings.subset_size:
-                    continue
-
-                # options_count will be zero for subbjective/numerical questions
-                question["options"] = [
-                    {"text": "", "image": None}
-                ] * options_count_per_set[question_index]
-                updated_subset_without_details.append(question)
-
-            quiz["question_sets"][question_set_index]["questions"][
-                settings.subset_size :
-            ] = updated_subset_without_details
+        project_omr_option_counts(
+            quiz["question_sets"], options_count_across_sets, settings.subset_size
+        )
 
     if quiz.get("display_solution", True) is False:
         _clear_solutions_in_place(quiz)

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -40,8 +40,9 @@ def project_omr_option_counts(question_sets, aggregated_results, subset_size):
                 continue
 
             # options_count will be zero for subjective/numerical questions.
-            question["options"] = [{"text": "", "image": None}] * options_count_per_set[
-                question_index
+            question["options"] = [
+                {"text": "", "image": None}
+                for _ in range(options_count_per_set[question_index])
             ]
             updated_subset_without_details.append(question)
 

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -331,6 +331,64 @@ class QuizTestCase(BaseTestCase):
                     for option in question["options"]:
                         assert "text" in option
 
+    def test_omr_option_projection_order_independent(self):
+        question_sets = [
+            {
+                "_id": "A",
+                "questions": [
+                    {"type": "single-choice", "options": []},
+                    {"type": "single-choice", "options": []},
+                ],
+            },
+            {
+                "_id": "B",
+                "questions": [
+                    {"type": "single-choice", "options": []},
+                    {"type": "single-choice", "options": []},
+                ],
+            },
+        ]
+
+        aggregated_results = [
+            {"question_set_id": "B", "options_count_per_set": [2, 4]},
+            {"question_set_id": "A", "options_count_per_set": [3, 1]},
+        ]
+
+        quizzes.project_omr_option_counts(
+            question_sets=question_sets,
+            aggregated_results=aggregated_results,
+            subset_size=0,
+        )
+
+        result_map = {
+            qset["_id"]: [
+                len(question.get("options") or []) for question in qset["questions"]
+            ]
+            for qset in question_sets
+        }
+
+        assert result_map["A"] == [3, 1]
+        assert result_map["B"] == [2, 4]
+
+    def test_omr_option_projection_raises_on_duplicate_question_set_id(self):
+        question_sets = [
+            {"_id": "A", "questions": [{"type": "single-choice", "options": []}]}
+        ]
+        aggregated_results = [
+            {"question_set_id": "A", "options_count_per_set": [2]},
+            {"question_set_id": "A", "options_count_per_set": [3]},
+        ]
+
+        try:
+            quizzes.project_omr_option_counts(
+                question_sets=question_sets,
+                aggregated_results=aggregated_results,
+                subset_size=0,
+            )
+            assert False, "Expected ValueError for duplicate question_set_id"
+        except ValueError as exc:
+            assert "Duplicate question_set_id" in str(exc)
+
     def test_single_page_mode_clears_solutions_when_display_solution_false(self):
         # Ensure at least one question has a non-empty solution in the questions collection
         qset_id = self.multi_qset_quiz["question_sets"][0]["_id"]


### PR DESCRIPTION


**PR Description**  
### Problem
OMR option projection relied on positional alignment between quiz question sets and aggregated results.  
When ordering differed, mapping became incorrect and could produce wrong option placeholders.

### What this PR changes
1. Replaced positional/index-based mapping with deterministic mapping by `question_set_id`.
2. Added strict duplicate-ID protection to prevent silent overwrites.
3. Added safe handling for missing/partial aggregated results to avoid crashes.
4. Preserved existing API shape and behavior while fixing correctness.
5. Added targeted tests for order independence and duplicate-ID detection.

### Files Changed
1. quizzes.py
2. test_quizzes.py

### Validation
1. Targeted tests pass (`test_quizzes`).
2. Full suite passes locally: `61 passed`.
3. Local endpoints healthy:
   - [http://127.0.0.1:8000/health](http://127.0.0.1:8000/health)
   - [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs)

### Issue
Fixes #148.