### PR TITLE
Add input validation to prevent empty quizzes and invalid data states

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 from typing import Optional, List, Union
 from bson import ObjectId
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, constr, conlist, conint
 from schemas import (
     QuestionType,
     PyObjectId,
@@ -17,7 +18,7 @@ answerType = Union[List[int], List[str], float, int, str, dict, None]
 
 class Organization(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
-    name: str
+    name: constr(min_length=1)
 
     class Config:
         allow_population_by_field_name = True
@@ -134,7 +135,7 @@ class Question(BaseModel):
     """Model for the body of the request that creates a question"""
 
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
-    text: str
+    text: constr(min_length=1)
     type: QuestionType
     instructions: Optional[str] = None
     image: Optional[Image] = None
@@ -215,7 +216,7 @@ class QuestionResponse(Question):
 
 class QuestionSet(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
-    questions: List[Question]
+    questions: conlist(Question, min_items=1)
     title: Optional[str] = None
     description: Optional[str] = None
     max_questions_allowed_to_attempt: int
@@ -232,10 +233,10 @@ class Quiz(BaseModel):
     """Model for the body of the request that creates a quiz"""
 
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
-    title: Optional[str]
-    question_sets: List[QuestionSet]
-    max_marks: int
-    num_graded_questions: int
+    title: constr(min_length=1)
+    question_sets: conlist(QuestionSet, min_items=1)
+    max_marks: conint(ge=1)
+    num_graded_questions: conint(ge=1)
     shuffle: bool = False
     num_attempts_allowed: int = 1
     time_limit: Optional[QuizTimeLimit] = None

--- a/app/tests/test_validation.py
+++ b/app/tests/test_validation.py
@@ -1,0 +1,49 @@
+from .base import BaseTestCase
+from fastapi import status
+import json
+
+class ValidationTestCase(BaseTestCase):
+    def test_create_quiz_empty_title_fails(self):
+        # Using a copy of valid data but with empty title
+        invalid_data = self.short_homework_quiz_data.copy()
+        invalid_data["title"] = ""
+        response = self.client.post("/quiz/", json=invalid_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_create_quiz_empty_question_sets_fails(self):
+        invalid_data = self.short_homework_quiz_data.copy()
+        invalid_data["question_sets"] = []
+        response = self.client.post("/quiz/", json=invalid_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_create_quiz_zero_marks_fails(self):
+        invalid_data = self.short_homework_quiz_data.copy()
+        invalid_data["max_marks"] = 0
+        response = self.client.post("/quiz/", json=invalid_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_create_organization_empty_name_fails(self):
+        invalid_data = {"name": ""}
+        response = self.client.post("/organizations/", json=invalid_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_create_question_empty_text_fails(self):
+        # We create questions via the quiz endpoint
+        invalid_data = self.short_homework_quiz_data.copy()
+        # Deep copy the question set to modify question text
+        invalid_data["question_sets"] = [
+            {
+                "title": "Set 1",
+                "max_questions_allowed_to_attempt": 1,
+                "questions": [
+                    {
+                        "text": "", # Invalid empty text
+                        "type": "single-choice",
+                        "options": [{"text": "Opt 1"}],
+                        "graded": True
+                    }
+                ]
+            }
+        ]
+        response = self.client.post("/quiz/", json=invalid_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary
Introduced content-level validation for Organization, Question, QuestionSet, and Quiz models using Pydantic `con*` types. This prevents invalid states like empty titles, empty question lists, and zero marks.

## Motivation
Prevents database pollution and frontend crashes by ensuring data integrity at the schema level. It also fixes a Pydantic type inference issue encountered on Python 3.14.

## Changes
- Updated `app/models.py` with validation constraints.
- Added `from __future__ import annotations` for Python 3.14 compatibility.
- Added comprehensive validation tests in `app/tests/test_validation.py`.
