### PR TITLE
Wire CMS service env into ECS task definitions (staging + prod)

### DIFF
--- a/terraform/prod/ecs.tf
+++ b/terraform/prod/ecs.tf
@@ -55,6 +55,14 @@ resource "aws_ecs_task_definition" "quiz_backend" {
         {
           name  = "MONGO_AUTH_CREDENTIALS"
           value = var.mongo_auth_credentials
+        },
+        {
+          name  = "CMS_SERVICE_ENDPOINT"
+          value = var.cms_service_endpoint
+        },
+        {
+          name  = "CMS_SERVICE_TOKEN"
+          value = var.cms_service_token
         }
       ]
 

--- a/terraform/prod/terraform.tfvars.example
+++ b/terraform/prod/terraform.tfvars.example
@@ -5,6 +5,11 @@ aws_region             = "ap-south-1"
 environment            = "prod"
 mongo_auth_credentials = "mongodb+srv://USER:PASS@cluster.mongodb.net/quiz-prod?retryWrites=true&w=majority"
 
+# New CMS (nex-gen-cms) service API — used by POST /quiz/from-cms to fetch tests.
+# cms_service_token MUST match the CMS's PROD CMS_SERVICE_TOKEN, else ingest 401s.
+cms_service_endpoint = "https://new-cms.avantifellows.org"
+cms_service_token    = "your-prod-cms-service-token"
+
 # ECS Configuration
 desired_count = 1
 task_cpu      = 1024  # 1 vCPU

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -55,3 +55,14 @@ variable "cloudflare_zone_name" {
   description = "Cloudflare zone name (e.g. avantifellows.org)"
   type        = string
 }
+
+variable "cms_service_endpoint" {
+  description = "Base URL of the new CMS (nex-gen-cms) service API, used for test ingest (e.g. https://new-cms.avantifellows.org)"
+  type        = string
+}
+
+variable "cms_service_token" {
+  description = "Bearer token for the new CMS service API. Must match the CMS's CMS_SERVICE_TOKEN for this environment, or /quiz/from-cms will 401."
+  type        = string
+  sensitive   = true
+}

--- a/terraform/testing/ecs.tf
+++ b/terraform/testing/ecs.tf
@@ -55,6 +55,14 @@ resource "aws_ecs_task_definition" "quiz_backend" {
         {
           name  = "MONGO_AUTH_CREDENTIALS"
           value = var.mongo_auth_credentials
+        },
+        {
+          name  = "CMS_SERVICE_ENDPOINT"
+          value = var.cms_service_endpoint
+        },
+        {
+          name  = "CMS_SERVICE_TOKEN"
+          value = var.cms_service_token
         }
       ]
 

--- a/terraform/testing/terraform.tfvars.example
+++ b/terraform/testing/terraform.tfvars.example
@@ -5,6 +5,11 @@ aws_region             = "ap-south-1"
 environment            = "testing"
 mongo_auth_credentials = "mongodb+srv://USER:PASS@cluster.mongodb.net/quiz-staging?retryWrites=true&w=majority"
 
+# New CMS (nex-gen-cms) service API — used by POST /quiz/from-cms to fetch tests.
+# cms_service_token MUST match the CMS's STAGING CMS_SERVICE_TOKEN, else ingest 401s.
+cms_service_endpoint = "https://staging-new-cms.avantifellows.org"
+cms_service_token    = "your-staging-cms-service-token"
+
 # ECS Configuration
 desired_count = 1
 task_cpu      = 1024  # 1 vCPU

--- a/terraform/testing/variables.tf
+++ b/terraform/testing/variables.tf
@@ -55,3 +55,14 @@ variable "cloudflare_zone_name" {
   description = "Cloudflare zone name (e.g. avantifellows.org)"
   type        = string
 }
+
+variable "cms_service_endpoint" {
+  description = "Base URL of the new CMS (nex-gen-cms) service API, used for test ingest (e.g. https://staging-new-cms.avantifellows.org)"
+  type        = string
+}
+
+variable "cms_service_token" {
+  description = "Bearer token for the new CMS service API. Must match the CMS's CMS_SERVICE_TOKEN for this environment, or /quiz/from-cms will 401."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Why
As part of **lms-cms-tests** (LMS session creator → new-CMS test ingest), af_lms calls quiz-backend `POST /quiz/from-cms`, which fetches the assembled test from the new CMS (nex-gen-cms) using `CMS_SERVICE_ENDPOINT` + `CMS_SERVICE_TOKEN`.

Those env vars were only ever injected by the **legacy SAM/Lambda** deploy (`deploy_to_{staging,prod}.yml` → SAM `--parameter-overrides`). The **ECS** task defs (`quiz-backend-prod`, `quiz-backend-testing`) carry **only `MONGO_AUTH_CREDENTIALS`** — verified against the live task defs. So on ECS, `/quiz/from-cms` can't reach the CMS: no endpoint, and the CMS is fail-closed → **401**.

Since we're **decommissioning Lambda and moving to ECS** for both staging and prod, the CMS config has to live in the ECS task definitions.

## What
- Add `cms_service_endpoint` and (sensitive) `cms_service_token` variables to `terraform/prod` and `terraform/testing`.
- Set `CMS_SERVICE_ENDPOINT` / `CMS_SERVICE_TOKEN` in the container `environment` for both.
- Document values in each `terraform.tfvars.example`.

Follows the existing `mongo_auth_credentials` pattern — values supplied per-env via `terraform.tfvars` at apply time (no CI reads them; there's no terraform workflow).

## Apply / rollout (manual, per env)
For **each** of `terraform/testing` and `terraform/prod`, set in `terraform.tfvars`:
- `cms_service_endpoint` → `https://staging-new-cms.avantifellows.org` (testing) / `https://new-cms.avantifellows.org` (prod)
- `cms_service_token` → **must equal the CMS's `CMS_SERVICE_TOKEN` for that env** (i.e. the value in nex-gen-cms `TF_VAR_CMS_SERVICE_TOKEN_STAGING` / `TF_VAR_CMS_SERVICE_TOKEN_PROD`), else ingest 401s.

Then `terraform apply` (registers a new task-def revision + rolls the service). The image-only `deploy_ecs_*` workflow preserves these env vars on subsequent deploys (it describes the current task def and only overrides the image).

## Verify after apply
```
curl -sS -o /dev/null -w "%{http_code}\n" -X POST -H "Content-Type: application/json" \
  -d '{"test_id":<real>,"curriculum_id":1,"grade_id":<real>,"quiz_type":"assessment"}' \
  https://quiz-backend.avantifellows.org/quiz/from-cms
```
Expect **201** (quiz built). A **502** means the CMS call failed (token/endpoint wrong).

> af_lms's prod `QUIZ_BACKEND_URL` will be repointed from the legacy execute-api Lambda to `https://quiz-backend.avantifellows.org` once this is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)