### PR TITLE
Add PATCH /quiz/{id} to patch session-editable settings in place

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -123,7 +123,10 @@ class QuizMetadata(BaseModel):
     topic: Optional[str]
     source: Optional[str]
     source_id: Optional[str]
-    session_end_time: Optional[str]  # format: %Y-%m-%d %I:%M:%S %p
+    # Answer-visibility time (ISO wall-clock): when review_immediate is false, the frontend
+    # defers answer review until now > this. Derived as session window end + quiz duration
+    # (services.quiz_time), so students still mid-test don't get early access.
+    session_end_time: Optional[str]
     next_step_url: Optional[str]  # URL to redirect to after quiz completion
     next_step_text: Optional[str]  # Text to display on the next step button
     next_step_autostart: Optional[bool] = False  # Whether next step should auto-start

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import APIRouter, status, HTTPException, Query
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -221,6 +223,78 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
             "source_id": str(request.test_id),
             "warnings": warnings,
         },
+    )
+
+
+class QuizPatchRequest(BaseModel):
+    """Body for PATCH /quiz/{quiz_id} — field-scoped update of the session-editable
+    settings on an existing quiz doc. Only the fields that are sent are changed; the
+    LMS session-edit flow decides which to send."""
+
+    title: Optional[str] = None
+    shuffle: Optional[bool] = None
+    show_scores: Optional[bool] = None
+    # "show answers immediately after submission" (off during concurrent testing)
+    review_immediate: Optional[bool] = None
+    # metadata.session_end_time, format: %Y-%m-%d %I:%M:%S %p
+    session_end_time: Optional[str] = None
+
+
+@router.patch("/{quiz_id}")
+async def patch_quiz(quiz_id: str, request: QuizPatchRequest):
+    """Patch session-editable settings on an existing quiz in place (same _id).
+
+    Called by the LMS when a quiz session is edited so the display/scoring settings
+    on the quiz doc stay in sync, without rebuilding the quiz or its questions.
+    """
+    quiz_collection = client.quiz.quizzes
+
+    existing = quiz_collection.find_one({"_id": quiz_id}, {"_id": 1, "metadata": 1})
+    if existing is None:
+        logger.warning(f"Requested quiz {quiz_id} not found for patch")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"quiz {quiz_id} not found"
+        )
+
+    set_ops = {}
+    updated = []
+    for field in ("title", "shuffle", "show_scores", "review_immediate"):
+        value = getattr(request, field)
+        if value is not None:
+            set_ops[field] = value
+            updated.append(field)
+    if request.session_end_time is not None:
+        updated.append("session_end_time")
+        # A dotted $set ("metadata.session_end_time") raises when metadata is
+        # explicitly null (Mongo can't traverse a null intermediate), so write the
+        # whole subdoc in that case. An absent metadata is fine with dot-notation.
+        if existing.get("metadata") is None:
+            set_ops["metadata"] = {"session_end_time": request.session_end_time}
+        else:
+            set_ops["metadata.session_end_time"] = request.session_end_time
+
+    if not set_ops:
+        return JSONResponse(
+            status_code=status.HTTP_200_OK, content={"id": quiz_id, "updated": []}
+        )
+
+    result = quiz_collection.update_one({"_id": quiz_id}, {"$set": set_ops})
+    if not result.acknowledged:
+        error_message = f"Failed to patch quiz {quiz_id}"
+        logger.error(error_message)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error_message
+        )
+    if result.matched_count == 0:
+        # Deleted between the existence check and the write.
+        logger.warning(f"Quiz {quiz_id} vanished before patch could apply")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"quiz {quiz_id} not found"
+        )
+    logger.info(f"Patched quiz {quiz_id}: {updated}")
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"id": quiz_id, "updated": updated},
     )
 
 

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -13,6 +13,7 @@ from services.cms_ingest import (
     map_cms_test_to_quiz,
     CmsIngestError,
 )
+from services.quiz_time import answer_visibility_end_time
 from logger_config import get_logger
 
 router = APIRouter(prefix="/quiz", tags=["Quiz"])
@@ -87,6 +88,44 @@ def update_quiz_for_backwards_compatibility(quiz_collection, quiz_id, quiz):
     logger.info("Quiz updated for backwards compatibility")
 
 
+def _aggregate_question_set_subset(question_set_id) -> list:
+    """Build the question list a quiz doc stores for one set: the first `subset_size`
+    questions in full detail plus the rest projected to grading-only fields. The questions
+    themselves live in full in the `questions` collection; this is the denormalized subset
+    embedded on the quiz. Shared by create and regenerate so both produce the same shape.
+
+    Questions are ordered by `_id`, which preserves authored order because ids are assigned
+    in list order at insert time — the create and regenerate paths rely on this to keep the
+    embedded subset aligned with the authored question order.
+    """
+    subset_with_details = client.quiz.questions.aggregate(
+        [
+            {"$match": {"question_set_id": question_set_id}},
+            {"$sort": {"_id": 1}},
+            {"$limit": settings.subset_size},
+        ]
+    )
+    subset_without_details = client.quiz.questions.aggregate(
+        [
+            {"$match": {"question_set_id": question_set_id}},
+            {"$sort": {"_id": 1}},
+            {"$skip": settings.subset_size},
+            {
+                "$project": {
+                    "graded": 1,
+                    "force_correct": 1,
+                    "type": 1,
+                    "matrix_rows": 1,
+                    "correct_answer": 1,
+                    "question_set_id": 1,
+                    "marking_scheme": 1,
+                }
+            },
+        ]
+    )
+    return list(subset_with_details) + list(subset_without_details)
+
+
 def _insert_quiz_with_questions(quiz: dict) -> str:
     """Insert a quiz (already jsonable-encoded) and its questions into Mongo, returning
     the new quiz id. Shared by the direct create endpoint and the CMS-ingest endpoint.
@@ -121,35 +160,9 @@ def _insert_quiz_with_questions(quiz: dict) -> str:
                 detail=error_message,
             )
 
-        subset_with_details = client.quiz.questions.aggregate(
-            [
-                {"$match": {"question_set_id": question_set["_id"]}},
-                {"$sort": {"_id": 1}},
-                {"$limit": settings.subset_size},
-            ]
-        )
-
-        subset_without_details = client.quiz.questions.aggregate(
-            [
-                {"$match": {"question_set_id": question_set["_id"]}},
-                {"$sort": {"_id": 1}},
-                {"$skip": settings.subset_size},
-                {
-                    "$project": {
-                        "graded": 1,
-                        "force_correct": 1,
-                        "type": 1,
-                        "matrix_rows": 1,
-                        "correct_answer": 1,
-                        "question_set_id": 1,
-                        "marking_scheme": 1,
-                    }
-                },
-            ]
-        )
-
-        aggregated_questions = list(subset_with_details) + list(subset_without_details)
-        quiz["question_sets"][question_set_index]["questions"] = aggregated_questions
+        quiz["question_sets"][question_set_index][
+            "questions"
+        ] = _aggregate_question_set_subset(question_set["_id"])
 
     new_quiz_result = client.quiz.quizzes.insert_one(quiz)
     if not new_quiz_result.acknowledged:
@@ -164,12 +177,19 @@ def _insert_quiz_with_questions(quiz: dict) -> str:
 
 
 class CmsQuizIngestRequest(BaseModel):
-    """Body for POST /quiz/from-cms — identifies a chapter test in the new CMS."""
+    """Body for POST /quiz/from-cms and PUT /quiz/{id}/from-cms — identifies a chapter test
+    in the new CMS, plus the optional session window end used to derive answer-visibility.
+    """
 
     test_id: int
     curriculum_id: int
     grade_id: int
     quiz_type: str = QuizType.assessment.value
+    # Raw session window-end as an ISO wall-clock string (IST), e.g. "2026-04-15T14:00:00".
+    # The stored metadata.session_end_time is this PLUS the quiz duration (see
+    # services.quiz_time) so students still mid-test don't get early answer access. Optional:
+    # untimed quizzes / callers that don't gate review can omit it.
+    session_end_time: Optional[str] = None
 
     class Config:
         schema_extra = {
@@ -178,6 +198,7 @@ class CmsQuizIngestRequest(BaseModel):
                 "curriculum_id": 1,
                 "grade_id": 1,
                 "quiz_type": "assessment",
+                "session_end_time": "2026-04-15T14:00:00",
             }
         }
 
@@ -208,6 +229,16 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
         logger.error(f"CMS ingest failed for test {request.test_id}: {exc}")
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
 
+    # Answer-visibility time = window end + quiz duration (see services.quiz_time). Set here
+    # at create so a CMS session with review_immediate=false defers review correctly; without
+    # it the quiz doc has no session_end_time and the frontend never gates review.
+    if request.session_end_time:
+        quiz_dict.setdefault("metadata", {})[
+            "session_end_time"
+        ] = answer_visibility_end_time(
+            request.session_end_time, quiz_dict.get("time_limit")
+        )
+
     # Validate + fill defaults (ids, etc.) through the same model the direct endpoint uses.
     quiz = jsonable_encoder(Quiz(**quiz_dict))
     quiz_id = _insert_quiz_with_questions(quiz)
@@ -226,6 +257,167 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
     )
 
 
+# Session-editable settings that live on the quiz doc (not the CMS source). Regenerate must
+# preserve these across a re-ingest — they were set by the LMS session-edit flow, not by the
+# test content, so re-pulling the test must not reset them.
+_SESSION_EDITABLE_QUIZ_FIELDS = ("title", "shuffle", "show_scores", "review_immediate")
+_SESSION_EDITABLE_METADATA_FIELDS = ("grade", "single_page_header_text")
+
+
+@router.put("/{quiz_id}/from-cms")
+async def regenerate_quiz_from_cms(quiz_id: str, request: CmsQuizIngestRequest):
+    """Re-ingest the (corrected) CMS test into an EXISTING quiz in place: the quiz keeps its
+    _id and every question-set / question _id, so the session and any submitted attempts stay
+    linked. Refreshes question content, answer key, marking, marks, timing and content
+    metadata (test_format/subject); preserves the session-editable settings on the quiz doc
+    (title, shuffle, show_scores, review_immediate, grade, single_page_header_text, and
+    session_end_time unless a new window end is supplied). Mirrors the legacy sessionCreator
+    regenerate path (patch_quiz_in_mongo, Mode B).
+
+    Refuses with 409 if the regenerated test's structure differs from the existing quiz
+    (different number of question sets, or a different question count in any set): the
+    positional _id mapping that keeps attempts linked would otherwise silently misalign.
+    """
+    logger.info(
+        f"CMS regenerate: quiz {quiz_id} from test {request.test_id} "
+        f"(curriculum {request.curriculum_id}, grade {request.grade_id})"
+    )
+    quiz_collection = client.quiz.quizzes
+    existing = quiz_collection.find_one({"_id": quiz_id})
+    if existing is None:
+        logger.warning(f"Requested quiz {quiz_id} not found for regenerate")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"quiz {quiz_id} not found"
+        )
+
+    try:
+        assembled = fetch_assembled_test(
+            request.test_id, request.curriculum_id, request.grade_id
+        )
+        new_quiz, warnings = map_cms_test_to_quiz(
+            assembled, quiz_type=request.quiz_type
+        )
+    except CmsIngestError as exc:
+        logger.error(f"CMS regenerate failed for test {request.test_id}: {exc}")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+    # Validate + fill defaults through the same model create uses (fresh set/question ids,
+    # which we then overwrite positionally with the existing ones below).
+    new_quiz = jsonable_encoder(Quiz(**new_quiz))
+
+    # The regenerated test must line up POSITIONALLY with the existing quiz, or the _id
+    # reuse below would remap answer keys onto the wrong questions and silently mis-score
+    # submitted attempts. Validate fully BEFORE any write: same set count, same per-set
+    # question count, and — the subtle one — the same question at each position. A
+    # delete+add or a reorder keeps the counts but changes identity; anchor on the CMS
+    # source_id (present on both sides for CMS quizzes) to catch it. Cache the fetched
+    # existing question docs so the write pass doesn't re-read them.
+    old_sets = existing.get("question_sets") or []
+    new_sets = new_quiz["question_sets"]
+    mismatch = None
+    existing_questions = {}  # (set_index, question_index) -> full existing question doc
+    if len(new_sets) != len(old_sets):
+        mismatch = f"question-set count changed ({len(old_sets)} -> {len(new_sets)})"
+    else:
+        for i, (old_s, new_s) in enumerate(zip(old_sets, new_sets)):
+            old_qs = old_s.get("questions") or []
+            new_qs = new_s.get("questions") or []
+            if len(old_qs) != len(new_qs):
+                mismatch = f"question count in set {i} changed ({len(old_qs)} -> {len(new_qs)})"
+                break
+            for j, (old_q, new_q) in enumerate(zip(old_qs, new_qs)):
+                existing_q = client.quiz.questions.find_one({"_id": old_q["_id"]}) or {}
+                existing_questions[(i, j)] = existing_q
+                old_src = existing_q.get("source_id")
+                new_src = new_q.get("source_id")
+                if old_src and new_src and str(old_src) != str(new_src):
+                    mismatch = (
+                        f"question {j} in set {i} is a different problem "
+                        f"(source_id {old_src} -> {new_src})"
+                    )
+                    break
+            if mismatch:
+                break
+    if mismatch:
+        logger.warning(f"Regenerate refused for quiz {quiz_id}: {mismatch}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"regenerated test differs from the existing quiz: {mismatch}. Regenerate "
+                "preserves attempt links by position and cannot remap a reshaped or "
+                "reordered test; create a new session for it instead."
+            ),
+        )
+
+    # Preserve the quiz _id and every set/question _id positionally, and refresh each question
+    # doc in the questions collection in place (back-filling any keys the new mapping drops).
+    # NOTE: this is not atomic — questions are replaced before the quiz doc, so a mid-loop
+    # failure leaves refreshed questions with a stale embedded grading subset. Tracked as debt
+    # (needs a replica-set transaction to fix); acceptable for a rare admin-triggered action.
+    new_quiz["_id"] = quiz_id
+    for i, new_s in enumerate(new_sets):
+        old_s = old_sets[i]
+        new_s["_id"] = old_s["_id"]
+        for j, new_q in enumerate(new_s["questions"]):
+            question_id = old_s["questions"][j]["_id"]
+            new_q["_id"] = question_id
+            new_q["question_set_id"] = new_s["_id"]
+            existing_q = existing_questions.get((i, j)) or {}
+            for key, value in existing_q.items():
+                if key not in new_q:
+                    new_q[key] = value
+            client.quiz.questions.replace_one({"_id": question_id}, new_q)
+        # Re-derive the embedded subset from the refreshed question docs.
+        new_s["questions"] = _aggregate_question_set_subset(new_s["_id"])
+
+    # Preserve session-editable settings the LMS set on the quiz doc (content comes from CMS).
+    for field in _SESSION_EDITABLE_QUIZ_FIELDS:
+        if field in existing:
+            new_quiz[field] = existing[field]
+
+    new_meta = new_quiz.get("metadata") or {}
+    old_meta = existing.get("metadata") or {}
+    for field in _SESSION_EDITABLE_METADATA_FIELDS:
+        if old_meta.get(field) is not None:
+            new_meta[field] = old_meta[field]
+    if request.session_end_time:
+        new_meta["session_end_time"] = answer_visibility_end_time(
+            request.session_end_time, new_quiz.get("time_limit")
+        )
+    elif old_meta.get("session_end_time") is not None:
+        new_meta["session_end_time"] = old_meta["session_end_time"]
+    new_quiz["metadata"] = new_meta
+
+    # Back-fill any other top-level keys the old doc carried but the new one lacks (legacy
+    # parity — don't drop engine-added fields).
+    for key, value in existing.items():
+        if key not in new_quiz:
+            new_quiz[key] = value
+
+    result = quiz_collection.replace_one({"_id": quiz_id}, new_quiz)
+    if not result.acknowledged:
+        error_message = f"Failed to regenerate quiz {quiz_id}"
+        logger.error(error_message)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error_message
+        )
+
+    if warnings:
+        logger.warning(
+            f"CMS regenerate for test {request.test_id} produced warnings: {warnings}"
+        )
+    logger.info(f"Regenerated quiz {quiz_id} from CMS test {request.test_id}")
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={
+            "id": quiz_id,
+            "source_id": str(request.test_id),
+            "warnings": warnings,
+            "regenerated": True,
+        },
+    )
+
+
 class QuizPatchRequest(BaseModel):
     """Body for PATCH /quiz/{quiz_id} — field-scoped update of the session-editable
     settings on an existing quiz doc. Only the fields that are sent are changed; the
@@ -236,7 +428,9 @@ class QuizPatchRequest(BaseModel):
     show_scores: Optional[bool] = None
     # "show answers immediately after submission" (off during concurrent testing)
     review_immediate: Optional[bool] = None
-    # metadata.session_end_time, format: %Y-%m-%d %I:%M:%S %p
+    # Raw session window-end (ISO wall-clock, e.g. "2026-04-15T14:00:00"). Stored as
+    # metadata.session_end_time PLUS the quiz duration (answer-visibility time); see
+    # services.quiz_time.
     session_end_time: Optional[str] = None
 
 
@@ -249,7 +443,9 @@ async def patch_quiz(quiz_id: str, request: QuizPatchRequest):
     """
     quiz_collection = client.quiz.quizzes
 
-    existing = quiz_collection.find_one({"_id": quiz_id}, {"_id": 1, "metadata": 1})
+    existing = quiz_collection.find_one(
+        {"_id": quiz_id}, {"_id": 1, "metadata": 1, "time_limit": 1}
+    )
     if existing is None:
         logger.warning(f"Requested quiz {quiz_id} not found for patch")
         raise HTTPException(
@@ -265,13 +461,18 @@ async def patch_quiz(quiz_id: str, request: QuizPatchRequest):
             updated.append(field)
     if request.session_end_time is not None:
         updated.append("session_end_time")
+        # Store the answer-visibility time (window end + quiz duration), reading the duration
+        # off the existing quiz doc — matches legacy sessionCreator; see services.quiz_time.
+        visibility_time = answer_visibility_end_time(
+            request.session_end_time, existing.get("time_limit")
+        )
         # A dotted $set ("metadata.session_end_time") raises when metadata is
         # explicitly null (Mongo can't traverse a null intermediate), so write the
         # whole subdoc in that case. An absent metadata is fine with dot-notation.
         if existing.get("metadata") is None:
-            set_ops["metadata"] = {"session_end_time": request.session_end_time}
+            set_ops["metadata"] = {"session_end_time": visibility_time}
         else:
-            set_ops["metadata.session_end_time"] = request.session_end_time
+            set_ops["metadata.session_end_time"] = visibility_time
 
     if not set_ops:
         return JSONResponse(

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -176,6 +176,16 @@ def _insert_quiz_with_questions(quiz: dict) -> str:
     return new_quiz_result.inserted_id
 
 
+# Display/scoring settings the LMS session form owns, stored on the quiz doc rather than
+# derived from the CMS test. Supplied on CREATE (see CmsQuizIngestRequest) and preserved
+# across a regenerate — a re-ingest refreshes content, never these.
+_SESSION_EDITABLE_QUIZ_SETTINGS = ("shuffle", "show_scores", "review_immediate")
+# ...plus the title, which regenerate must also keep (the LMS names the session, and the CMS
+# test name would otherwise clobber a renamed session). Not settable via the create body:
+# create takes the title straight from the mapped CMS test.
+_SESSION_EDITABLE_QUIZ_FIELDS = ("title",) + _SESSION_EDITABLE_QUIZ_SETTINGS
+
+
 class CmsQuizIngestRequest(BaseModel):
     """Body for POST /quiz/from-cms and PUT /quiz/{id}/from-cms — identifies a chapter test
     in the new CMS, plus the optional session window end used to derive answer-visibility.
@@ -191,6 +201,19 @@ class CmsQuizIngestRequest(BaseModel):
     # untimed quizzes / callers that don't gate review can omit it.
     session_end_time: Optional[str] = None
 
+    # Session-level display/scoring settings chosen by the PM in the LMS session form. The
+    # CMS test carries no notion of these, so the mapper emits hardcoded defaults
+    # (shuffle=False) and the Quiz model fills the rest (review_immediate/show_scores=True).
+    # Without them on CREATE, a PM who ticked "shuffle" got a quiz that never shuffled and
+    # one who unticked "show answers" got answers shown immediately, since the quiz-taking
+    # frontend reads all three off the quiz doc, not the session row. Omitted (None) means
+    # "leave the default" — on regenerate these are ignored in favour of the values already
+    # on the doc (see _SESSION_EDITABLE_QUIZ_FIELDS).
+    shuffle: Optional[bool] = None
+    show_scores: Optional[bool] = None
+    # "show answers immediately after submission" in the LMS form.
+    review_immediate: Optional[bool] = None
+
     class Config:
         schema_extra = {
             "example": {
@@ -199,6 +222,9 @@ class CmsQuizIngestRequest(BaseModel):
                 "grade_id": 1,
                 "quiz_type": "assessment",
                 "session_end_time": "2026-04-15T14:00:00",
+                "shuffle": True,
+                "show_scores": True,
+                "review_immediate": False,
             }
         }
 
@@ -239,6 +265,14 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
             request.session_end_time, quiz_dict.get("time_limit")
         )
 
+    # Apply the PM's session settings over the mapper's defaults. The quiz-taking frontend
+    # reads these off the quiz doc, so skipping them here silently discards the choice made
+    # in the LMS form. Only fields explicitly supplied are overridden.
+    for field in _SESSION_EDITABLE_QUIZ_SETTINGS:
+        value = getattr(request, field)
+        if value is not None:
+            quiz_dict[field] = value
+
     # Validate + fill defaults (ids, etc.) through the same model the direct endpoint uses.
     quiz = jsonable_encoder(Quiz(**quiz_dict))
     quiz_id = _insert_quiz_with_questions(quiz)
@@ -257,10 +291,6 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
     )
 
 
-# Session-editable settings that live on the quiz doc (not the CMS source). Regenerate must
-# preserve these across a re-ingest — they were set by the LMS session-edit flow, not by the
-# test content, so re-pulling the test must not reset them.
-_SESSION_EDITABLE_QUIZ_FIELDS = ("title", "shuffle", "show_scores", "review_immediate")
 _SESSION_EDITABLE_METADATA_FIELDS = ("grade", "single_page_header_text")
 
 

--- a/app/services/quiz_time.py
+++ b/app/services/quiz_time.py
@@ -1,0 +1,94 @@
+"""
+Answer-visibility time computation for quiz sessions.
+
+The quiz-taking frontend defers answer/solution review until the wall-clock passes
+`quiz.metadata.session_end_time` (Player.vue, when review_immediate is false). To stop a
+student who is still mid-test from seeing answers, that stored time must be the moment the
+LAST possible attempt could finish: the session window end PLUS the quiz duration
+(`time_limit.max`), NOT the raw window end.
+
+This mirrors the legacy sessionCreator exactly (etl-data-flow
+flows/sessionCreator/SessionCreator.py `_quiz_answer_visibility_end_time`), which this
+service's create/patch/regenerate paths replace. Ported verbatim so a session edited or
+regenerated here stores the same value the legacy Lambda would have.
+"""
+
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+from logger_config import get_logger
+
+logger = get_logger()
+
+# Non-ISO wall-clock formats we accept, in addition to datetime.fromisoformat. The 12-hour
+# "%I:%M:%S %p" form is what the quiz doc has historically stored (and what the LMS emits
+# today), so it must parse or the duration offset would be silently dropped.
+_FALLBACK_FORMATS = ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %I:%M:%S %p")
+
+
+def parse_quiz_end_time(end_time: Any) -> Optional[datetime]:
+    """Parse a window-end value (ISO string, "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %I:%M:%S %p", or
+    datetime) into a naive datetime (tz stripped, microseconds zeroed). None if unparseable.
+    """
+    if not end_time:
+        return None
+
+    if isinstance(end_time, datetime):
+        parsed = end_time
+        if parsed.tzinfo is not None:
+            parsed = parsed.replace(tzinfo=None)
+        return parsed.replace(microsecond=0)
+
+    if not isinstance(end_time, str):
+        return None
+
+    normalized = end_time
+    if normalized.endswith("Z"):
+        normalized = normalized.replace("Z", "+00:00")
+
+    parsed = None
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        for fmt in _FALLBACK_FORMATS:
+            try:
+                parsed = datetime.strptime(normalized, fmt)
+                break
+            except ValueError:
+                continue
+    if parsed is None:
+        return None
+
+    if parsed.tzinfo is not None:
+        parsed = parsed.replace(tzinfo=None)
+
+    return parsed.replace(microsecond=0)
+
+
+def quiz_duration_seconds(time_limit: Any) -> int:
+    """The quiz duration in seconds from a time_limit {min, max} dict. 0 if unset/untimed."""
+    if not isinstance(time_limit, dict):
+        return 0
+    try:
+        return int(time_limit.get("max") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def answer_visibility_end_time(window_end: Any, time_limit: Any) -> Optional[str]:
+    """Answer-visibility moment = window_end + quiz duration, as an isoformat string.
+
+    Returns None if `window_end` is falsy, or the original value (unchanged) if it cannot be
+    parsed — matching legacy, which never fabricates a time it can't derive."""
+    if not window_end:
+        return None
+    parsed = parse_quiz_end_time(window_end)
+    if parsed is None:
+        # Can't derive the visibility offset — store the value as given (legacy behaviour),
+        # but make the dropped offset visible rather than a silent early-answer hole.
+        logger.warning(
+            f"session window end {window_end!r} is unparseable; storing without the "
+            "quiz-duration offset (answer review may open at the window end, not later)"
+        )
+        return window_end
+    return (parsed + timedelta(seconds=quiz_duration_seconds(time_limit))).isoformat()

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -1,4 +1,6 @@
+import copy
 import json
+from unittest.mock import patch
 from .base import BaseTestCase
 from ..routers import quizzes, questions
 from settings import Settings
@@ -367,7 +369,9 @@ class QuizTestCase(BaseTestCase):
         assert found.get("solution") == []
 
     def test_patch_quiz_updates_session_editable_fields(self):
-        quiz_id = self.homework_quiz_id
+        # Timed quiz (time_limit.max = 200s): the stored session_end_time is the supplied
+        # window end PLUS the quiz duration (answer-visibility time), not the raw window end.
+        quiz_id = self.timed_quiz_id
         resp = self.client.patch(
             f"{quizzes.router.prefix}/{quiz_id}",
             json={
@@ -375,7 +379,7 @@ class QuizTestCase(BaseTestCase):
                 "shuffle": True,
                 "show_scores": False,
                 "review_immediate": False,
-                "session_end_time": "2026-04-15 02:00:00 PM",
+                "session_end_time": "2026-04-15T14:00:00",
             },
         )
         assert resp.status_code == 200
@@ -394,7 +398,19 @@ class QuizTestCase(BaseTestCase):
         assert doc["shuffle"] is True
         assert doc["show_scores"] is False
         assert doc["review_immediate"] is False
-        assert doc["metadata"]["session_end_time"] == "2026-04-15 02:00:00 PM"
+        # 14:00:00 + 200s = 14:03:20
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
+
+    def test_patch_quiz_session_end_time_untimed_quiz_has_no_offset(self):
+        # An untimed quiz (time_limit None) adds no duration; the value is just normalized.
+        quiz_id = self.homework_quiz_id
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15T14:00:00"},
+        )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:00:00"
 
     def test_patch_quiz_session_end_time_when_metadata_is_null(self):
         # A quiz doc can carry metadata: null (the GET route guards for it). A dotted
@@ -406,13 +422,27 @@ class QuizTestCase(BaseTestCase):
 
         resp = self.client.patch(
             f"{quizzes.router.prefix}/{quiz_id}",
-            json={"session_end_time": "2026-04-15 02:00:00 PM"},
+            json={"session_end_time": "2026-04-15T14:00:00"},
         )
         assert resp.status_code == 200
         assert resp.json()["updated"] == ["session_end_time"]
 
         doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
-        assert doc["metadata"] == {"session_end_time": "2026-04-15 02:00:00 PM"}
+        # untimed quiz -> no offset, value normalized to isoformat
+        assert doc["metadata"] == {"session_end_time": "2026-04-15T14:00:00"}
+
+    def test_patch_quiz_session_end_time_accepts_12h_format(self):
+        # The LMS emits the legacy 12-hour "%I:%M:%S %p" format; it must parse and still get
+        # the duration offset (else the answer-review gate silently opens at the window end).
+        quiz_id = self.timed_quiz_id  # time_limit.max = 200s
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15 02:00:00 PM"},
+        )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        # 14:00:00 + 200s = 14:03:20
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
 
     def test_patch_quiz_only_touches_provided_fields(self):
         quiz_id = self.short_homework_quiz_id
@@ -438,5 +468,185 @@ class QuizTestCase(BaseTestCase):
     def test_patch_quiz_returns_404_for_unknown_id(self):
         resp = self.client.patch(
             f"{quizzes.router.prefix}/does-not-exist", json={"shuffle": True}
+        )
+        assert resp.status_code == 404
+
+    # ---- CMS from-cms create: answer-visibility time ----
+
+    def _cms_quiz_dict(self, **overrides):
+        """A quiz dict shaped like map_cms_test_to_quiz's output (1 set, 2 questions), built
+        off the homework fixture. `overrides` shallow-merge onto the top level."""
+        quiz = copy.deepcopy(self.homework_quiz_data)
+        quiz.update(overrides)
+        return quiz
+
+    def test_create_from_cms_stores_answer_visibility_time(self):
+        quiz_dict = self._cms_quiz_dict(time_limit={"min": 0, "max": 200})
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "session_end_time": "2026-04-15T14:00:00",
+                },
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        # 14:00:00 + 200s duration = 14:03:20
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
+
+    def test_create_from_cms_without_session_end_time_leaves_it_unset(self):
+        quiz_dict = self._cms_quiz_dict(time_limit={"min": 0, "max": 200})
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["metadata"].get("session_end_time") is None
+
+    # ---- regenerate in place (PUT /quiz/{id}/from-cms) ----
+
+    def test_regenerate_preserves_ids_and_refreshes_content(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        # Session-edit sets these on the quiz doc; regenerate must not reset them.
+        self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"title": "LMS Session Name", "show_scores": False},
+        )
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        old_qids = [q["_id"] for q in before["question_sets"][0]["questions"]]
+
+        # Corrected test: same structure, changed content + content-metadata.
+        new_quiz = self._cms_quiz_dict()
+        new_quiz["title"] = "CMS Test Title"  # must NOT overwrite the session name
+        new_quiz["question_sets"][0]["questions"][0]["text"] = "CORRECTED text"
+        new_quiz["metadata"]["subject"] = "Physics"  # content metadata -> refreshes
+        new_quiz["metadata"]["grade"] = "99"  # session-editable metadata -> preserved
+
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["regenerated"] is True
+
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        # quiz + question ids preserved (attempts stay linked)
+        assert after["_id"] == quiz_id
+        assert [q["_id"] for q in after["question_sets"][0]["questions"]] == old_qids
+        # question content refreshed in the questions collection
+        assert (
+            mongo_client.quiz.questions.find_one({"_id": old_qids[0]})["text"]
+            == "CORRECTED text"
+        )
+        # session-editable settings preserved
+        assert after["title"] == "LMS Session Name"
+        assert after["show_scores"] is False
+        assert after["metadata"]["grade"] == "8"  # old value kept, not the CMS "99"
+        # content metadata refreshed from the corrected test
+        assert after["metadata"]["subject"] == "Physics"
+
+    def test_regenerate_recomputes_session_end_time_with_supplied_window(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        new_quiz = self._cms_quiz_dict(time_limit={"min": 0, "max": 200})
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "session_end_time": "2026-04-15T14:00:00",
+                },
+            )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
+
+    def test_regenerate_preserves_session_end_time_when_not_supplied(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15T14:00:00"},  # untimed -> stored as-is
+        )
+        new_quiz = self._cms_quiz_dict()
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:00:00"
+
+    def test_regenerate_refuses_structure_change(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+
+        new_quiz = self._cms_quiz_dict()  # add a 3rd question -> structure differs
+        new_quiz["question_sets"][0]["questions"].append(
+            copy.deepcopy(new_quiz["question_sets"][0]["questions"][0])
+        )
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 409
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        # nothing was written
+        assert len(after["question_sets"][0]["questions"]) == len(
+            before["question_sets"][0]["questions"]
+        )
+
+    def test_regenerate_refuses_when_question_identity_changes(self):
+        # Same set/question counts, but a position is now a DIFFERENT problem (source_id
+        # changed) — a reorder or delete+add. Blindly reusing the old _id would mis-score
+        # attempts, so this must 409 with no write.
+        seed = copy.deepcopy(self.homework_quiz_data)
+        for idx, q in enumerate(seed["question_sets"][0]["questions"]):
+            q["source_id"] = f"cms-{idx}"
+        quiz_id, _ = self.post_and_get_quiz(seed)
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        old_q0_id = before["question_sets"][0]["questions"][0]["_id"]
+
+        new_quiz = copy.deepcopy(seed)
+        new_quiz["question_sets"][0]["questions"][0]["source_id"] = "cms-999"
+
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 409
+        # no write happened — the question keeps its original source_id
+        assert (
+            mongo_client.quiz.questions.find_one({"_id": old_q0_id})["source_id"]
+            == "cms-0"
+        )
+
+    def test_regenerate_returns_404_for_unknown_id(self):
+        resp = self.client.put(
+            f"{quizzes.router.prefix}/does-not-exist/from-cms",
+            json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
         )
         assert resp.status_code == 404

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -365,3 +365,78 @@ class QuizTestCase(BaseTestCase):
                 break
         assert found is not None
         assert found.get("solution") == []
+
+    def test_patch_quiz_updates_session_editable_fields(self):
+        quiz_id = self.homework_quiz_id
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={
+                "title": "Renamed by LMS",
+                "shuffle": True,
+                "show_scores": False,
+                "review_immediate": False,
+                "session_end_time": "2026-04-15 02:00:00 PM",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == quiz_id
+        assert set(body["updated"]) == {
+            "title",
+            "shuffle",
+            "show_scores",
+            "review_immediate",
+            "session_end_time",
+        }
+
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["title"] == "Renamed by LMS"
+        assert doc["shuffle"] is True
+        assert doc["show_scores"] is False
+        assert doc["review_immediate"] is False
+        assert doc["metadata"]["session_end_time"] == "2026-04-15 02:00:00 PM"
+
+    def test_patch_quiz_session_end_time_when_metadata_is_null(self):
+        # A quiz doc can carry metadata: null (the GET route guards for it). A dotted
+        # $set would raise on the null intermediate; the endpoint must handle it.
+        quiz_id = self.homework_quiz_id
+        mongo_client.quiz.quizzes.update_one(
+            {"_id": quiz_id}, {"$set": {"metadata": None}}
+        )
+
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15 02:00:00 PM"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == ["session_end_time"]
+
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"] == {"session_end_time": "2026-04-15 02:00:00 PM"}
+
+    def test_patch_quiz_only_touches_provided_fields(self):
+        quiz_id = self.short_homework_quiz_id
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}", json={"shuffle": True}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == ["shuffle"]
+
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert after["shuffle"] is True
+        # untouched field stays as it was
+        assert after["title"] == before["title"]
+
+    def test_patch_quiz_with_no_fields_is_a_noop(self):
+        quiz_id = self.homework_quiz_id
+        resp = self.client.patch(f"{quizzes.router.prefix}/{quiz_id}", json={})
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == []
+
+    def test_patch_quiz_returns_404_for_unknown_id(self):
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/does-not-exist", json={"shuffle": True}
+        )
+        assert resp.status_code == 404

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -516,7 +516,8 @@ class QuizTestCase(BaseTestCase):
 
     def test_create_from_cms_applies_session_settings(self):
         """The PM's advanced-settings choices must land on the quiz doc: the quiz-taking
-        frontend reads shuffle/show_scores/review_immediate from there, not the session."""
+        frontend reads shuffle/show_scores/review_immediate from there, not the session.
+        """
         quiz_dict = self._cms_quiz_dict()
         # The mapper hardcodes shuffle=False and leaves the other two to the model defaults,
         # so all three differ from what's requested below.

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -512,6 +512,104 @@ class QuizTestCase(BaseTestCase):
         doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
         assert doc["metadata"].get("session_end_time") is None
 
+    # ---- CMS from-cms create: session settings ----
+
+    def test_create_from_cms_applies_session_settings(self):
+        """The PM's advanced-settings choices must land on the quiz doc: the quiz-taking
+        frontend reads shuffle/show_scores/review_immediate from there, not the session."""
+        quiz_dict = self._cms_quiz_dict()
+        # The mapper hardcodes shuffle=False and leaves the other two to the model defaults,
+        # so all three differ from what's requested below.
+        quiz_dict["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "shuffle": True,
+                    "show_scores": False,
+                    "review_immediate": False,
+                },
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["shuffle"] is True
+        assert doc["show_scores"] is False
+        assert doc["review_immediate"] is False
+
+    def test_create_from_cms_without_settings_keeps_defaults(self):
+        """Omitted settings leave the mapper/model defaults alone — the field-scoped body
+        must not coerce None onto the doc."""
+        quiz_dict = self._cms_quiz_dict()
+        quiz_dict["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["shuffle"] is False
+        assert doc["show_scores"] is True
+        assert doc["review_immediate"] is True
+
+    def test_create_from_cms_applies_a_single_setting_in_isolation(self):
+        """shuffle alone must not disturb the other two."""
+        quiz_dict = self._cms_quiz_dict()
+        quiz_dict["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "shuffle": True,
+                },
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["shuffle"] is True
+        assert doc["show_scores"] is True
+        assert doc["review_immediate"] is True
+
+    def test_regenerate_ignores_settings_in_body_and_keeps_doc_values(self):
+        """Regenerate preserves whatever the session-edit flow last set, even if the body
+        carries settings — the create and regenerate paths share one request model."""
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"shuffle": True, "show_scores": False},
+        )
+
+        new_quiz = self._cms_quiz_dict()
+        new_quiz["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "shuffle": False,
+                    "show_scores": True,
+                },
+            )
+        assert resp.status_code == 200
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert after["shuffle"] is True
+        assert after["show_scores"] is False
+
     # ---- regenerate in place (PUT /quiz/{id}/from-cms) ----
 
     def test_regenerate_preserves_ids_and_refreshes_content(self):


### PR DESCRIPTION
## What
New field-scoped endpoint **`PATCH /quiz/{quiz_id}`** that `$set`s only the session-editable settings on an existing quiz doc, in place (same `_id`): `title`, `shuffle`, `show_scores`, `review_immediate`, and `metadata.session_end_time`.

## Why
Part of the CMS quiz-sessions Phase 2 work (task `lms-cms-session-edit-regen`, stream 1). The LMS session-edit flow now writes each field directly to its source of truth instead of firing the legacy SNS → etl-data-flow `patch_session` (which KeyErrored on CMS sessions' absent `meta_data.course`). The quiz-taking frontend reads display/scoring settings from the quiz doc, so the LMS calls this endpoint to keep it in sync — without rebuilding the quiz or its questions.

## Behaviour
- Only fields present in the body are changed; empty body is a `200` no-op (`{"updated": []}`).
- `review_immediate` = "show answers immediately after submission".
- **Null-safe on `metadata`**: a dotted `$set` raises when `metadata` is explicitly `null`, so the whole subdoc is written in that case; absent metadata uses dot-notation.
- `404` on a missing quiz, and on a quiz deleted between the existence check and the write.
- No auth — consistent with the rest of the quiz router (CORS-gated).

## Tests
`app/tests/test_quizzes.py`: multi-field update, single-field isolation, no-op, null-metadata regression, 404.

## Deploy note
The af_lms edit route (separate PR) depends on this endpoint — **this must deploy first**, or CMS session edits will 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)