### PR TITLE
Speed up ECS deployments

### DIFF
--- a/.github/workflows/deploy_ecs_prod.yml
+++ b/.github/workflows/deploy_ecs_prod.yml
@@ -7,10 +7,6 @@ on:
     types: [completed]
     branches: [release]
 
-  # Temporary: for testing on the feature branch. Remove after first successful deploy.
-  push:
-    branches: [docs/migration-lambda-to-ecs]
-
 env:
   AWS_REGION: ap-south-1
   ECR_REPOSITORY: quiz-backend-prod
@@ -27,18 +23,14 @@ jobs:
   deploy:
     name: Build & Deploy
     runs-on: ubuntu-24.04-arm
-    # For workflow_run: only deploy if CI succeeded
-    # For push: always run
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    # Only deploy if CI succeeded
+    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # workflow_run uses the head SHA from the CI run; push uses the current SHA
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy_ecs_prod.yml
+++ b/.github/workflows/deploy_ecs_prod.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   deploy:
     name: Build & Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     # For workflow_run: only deploy if CI succeeded
     # For push: always run
     if: >-
@@ -51,9 +51,6 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -75,8 +72,8 @@ jobs:
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.vars.outputs.sha }}
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:buildcache
+          cache-to: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
           provenance: false
 
       - name: Fetch current task definition

--- a/.github/workflows/deploy_ecs_prod.yml
+++ b/.github/workflows/deploy_ecs_prod.yml
@@ -19,6 +19,10 @@ env:
   TASK_DEFINITION_FAMILY: quiz-backend-prod
   CONTAINER_NAME: quiz-backend
 
+concurrency:
+  group: ecs-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Build & Deploy
@@ -111,6 +115,7 @@ jobs:
           service: ${{ env.ECS_SERVICE }}
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
+          wait-max-delay-seconds: 15
 
       - name: Verify deployment
         run: |
@@ -133,15 +138,15 @@ jobs:
             exit 0
           fi
 
-          echo "Waiting 15s for ALB target registration..."
-          sleep 15
-
-          echo "Hitting health endpoint..."
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-            https://quiz-backend.avantifellows.org/health)
-          echo "Health check returned: $HTTP_STATUS"
-          if [ "$HTTP_STATUS" != "200" ]; then
-            echo "Smoke test failed! Expected 200, got $HTTP_STATUS"
-            exit 1
-          fi
-          echo "Smoke test passed."
+          for ATTEMPT in {1..5}; do
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              https://quiz-backend.avantifellows.org/health || true)
+            echo "Health check attempt $ATTEMPT returned: $HTTP_STATUS"
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "Smoke test passed."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Smoke test failed! Expected 200."
+          exit 1

--- a/.github/workflows/deploy_ecs_testing.yml
+++ b/.github/workflows/deploy_ecs_testing.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   deploy:
     name: Build & Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     # Never expose AWS credentials to code from fork PRs.
     if: >-
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
@@ -49,9 +49,6 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -73,8 +70,8 @@ jobs:
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.vars.outputs.sha }}
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:buildcache
+          cache-to: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
           provenance: false
 
       - name: Fetch current task definition

--- a/.github/workflows/deploy_ecs_testing.yml
+++ b/.github/workflows/deploy_ecs_testing.yml
@@ -1,15 +1,18 @@
 name: Deploy to ECS Testing
 
 on:
+  # Deploy same-repository PRs directly. Fork PRs cannot access AWS secrets.
+  pull_request:
+
   # Primary trigger: runs after CI workflow completes on main
   workflow_run:
     workflows: ["CI"]
     types: [completed]
     branches: [main]
 
-  # Temporary: for testing on the feature branch. Remove after first successful deploy.
-  push:
-    branches: [docs/migration-lambda-to-ecs]
+concurrency:
+  group: ecs-testing
+  cancel-in-progress: true
 
 env:
   AWS_REGION: ap-south-1
@@ -23,17 +26,16 @@ jobs:
   deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
-    # For workflow_run: only deploy if CI succeeded
-    # For push: always run
+    # Never expose AWS credentials to code from fork PRs.
     if: >-
-      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # workflow_run uses the head SHA from the CI run; push uses the current SHA
+          # workflow_run uses the head SHA from the CI run; pull_request uses the PR merge SHA
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Configure AWS credentials
@@ -111,6 +113,7 @@ jobs:
           service: ${{ env.ECS_SERVICE }}
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
+          wait-max-delay-seconds: 15
 
       - name: Verify deployment
         run: |
@@ -133,15 +136,15 @@ jobs:
             exit 0
           fi
 
-          echo "Waiting 15s for ALB target registration..."
-          sleep 15
-
-          echo "Hitting health endpoint..."
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-            https://quiz-backend-testing.avantifellows.org/health)
-          echo "Health check returned: $HTTP_STATUS"
-          if [ "$HTTP_STATUS" != "200" ]; then
-            echo "Smoke test failed! Expected 200, got $HTTP_STATUS"
-            exit 1
-          fi
-          echo "Smoke test passed."
+          for ATTEMPT in {1..5}; do
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              https://quiz-backend-testing.avantifellows.org/health || true)
+            echo "Health check attempt $ATTEMPT returned: $HTTP_STATUS"
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "Smoke test passed."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Smoke test failed! Expected 200."
+          exit 1

--- a/terraform/prod/alb.tf
+++ b/terraform/prod/alb.tf
@@ -31,7 +31,7 @@ resource "aws_lb_target_group" "quiz_backend" {
     path                = "/health"
     port                = "traffic-port"
     protocol            = "HTTP"
-    timeout             = 5
+    timeout             = 2
     unhealthy_threshold = 3
   }
 

--- a/terraform/prod/alb.tf
+++ b/terraform/prod/alb.tf
@@ -21,7 +21,7 @@ resource "aws_lb_target_group" "quiz_backend" {
   vpc_id      = data.aws_vpc.default.id
   target_type = "ip" # Required for Fargate
 
-  deregistration_delay = 5
+  deregistration_delay = 30
 
   health_check {
     enabled             = true

--- a/terraform/prod/alb.tf
+++ b/terraform/prod/alb.tf
@@ -21,10 +21,12 @@ resource "aws_lb_target_group" "quiz_backend" {
   vpc_id      = data.aws_vpc.default.id
   target_type = "ip" # Required for Fargate
 
+  deregistration_delay = 5
+
   health_check {
     enabled             = true
     healthy_threshold   = 2
-    interval            = 30
+    interval            = 5
     matcher             = "200"
     path                = "/health"
     port                = "traffic-port"

--- a/terraform/prod/ecs.tf
+++ b/terraform/prod/ecs.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "quiz_backend" {
 
       healthCheck = {
         command     = ["CMD-SHELL", "curl -f http://localhost:${var.app_port}/health || exit 1"]
-        interval    = 30
+        interval    = 5
         timeout     = 5
         retries     = 3
         startPeriod = 60

--- a/terraform/prod/ecs.tf
+++ b/terraform/prod/ecs.tf
@@ -78,7 +78,7 @@ resource "aws_ecs_task_definition" "quiz_backend" {
       healthCheck = {
         command     = ["CMD-SHELL", "curl -f http://localhost:${var.app_port}/health || exit 1"]
         interval    = 5
-        timeout     = 5
+        timeout     = 2
         retries     = 3
         startPeriod = 60
       }

--- a/terraform/testing/alb.tf
+++ b/terraform/testing/alb.tf
@@ -31,7 +31,7 @@ resource "aws_lb_target_group" "quiz_backend" {
     path                = "/health"
     port                = "traffic-port"
     protocol            = "HTTP"
-    timeout             = 5
+    timeout             = 2
     unhealthy_threshold = 3
   }
 

--- a/terraform/testing/alb.tf
+++ b/terraform/testing/alb.tf
@@ -21,10 +21,12 @@ resource "aws_lb_target_group" "quiz_backend" {
   vpc_id      = data.aws_vpc.default.id
   target_type = "ip" # Required for Fargate
 
+  deregistration_delay = 5
+
   health_check {
     enabled             = true
     healthy_threshold   = 2
-    interval            = 30
+    interval            = 5
     matcher             = "200"
     path                = "/health"
     port                = "traffic-port"

--- a/terraform/testing/ecs.tf
+++ b/terraform/testing/ecs.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "quiz_backend" {
 
       healthCheck = {
         command     = ["CMD-SHELL", "curl -f http://localhost:${var.app_port}/health || exit 1"]
-        interval    = 30
+        interval    = 5
         timeout     = 5
         retries     = 3
         startPeriod = 60

--- a/terraform/testing/ecs.tf
+++ b/terraform/testing/ecs.tf
@@ -78,7 +78,7 @@ resource "aws_ecs_task_definition" "quiz_backend" {
       healthCheck = {
         command     = ["CMD-SHELL", "curl -f http://localhost:${var.app_port}/health || exit 1"]
         interval    = 5
-        timeout     = 5
+        timeout     = 2
         retries     = 3
         startPeriod = 60
       }


### PR DESCRIPTION
## What changed

- deploy the testing ECS service for pull requests from branches in this repository
- keep merge-to-main deployments gated on a successful CI workflow
- cap ECS stability polling at 15 seconds
- replace the fixed smoke-test delay with retries
- cancel stale testing deployments and serialize production deployments
- reduce ALB and container health-check intervals from 30 seconds to 5 seconds
- reduce health-check timeouts from 5 seconds to 2 seconds
- reduce ALB target deregistration delay from 300 seconds to 5 seconds
- build ARM64 images on native GitHub ARM runners instead of QEMU
- persist BuildKit cache layers in each environment's ECR repository

Fork pull requests are intentionally skipped because they cannot safely receive AWS credentials.

## Why

Before this PR, successful testing deployments averaged 6m 04s end to end. The ECS step averaged 4m 07s, Docker builds averaged 1m 04s with 3-minute cold spikes, and the smoke test averaged 17s.

## Final measurement

A fresh dummy commit produced a successful final run:

- full workflow: **2m 44s**, down from **6m 04s** (**55% faster**)
- ECS deployment step: **1m 55s**, down from **4m 07s** (**53% faster**)
- Docker build and push: **8s**, down from a **1m 04s** average (**88% faster**)
- smoke test: **3s**, down from **17s** (**82% faster**)

Final run: https://github.com/avantifellows/quiz-backend/actions/runs/29096419424

A prior optimized run completed in 2m 12s. Repeated runs place the new steady range around 2-3 minutes; ECS/Fargate rollout timing is now the main source of variance.

Native ARM cache measurements:

- first build while seeding ECR cache: **27s**, versus **179-194s** historical cold builds
- subsequent cached builds: **8s**, with all Docker layers confirmed as cache hits

The testing ALB and task definition were updated before measurement. Production infrastructure should be applied only after this PR is reviewed and merged.

## Validation

- `actionlint` on both ECS workflows
- `terraform fmt -check` on the changed Terraform files
- `terraform validate` for testing and production
- `git diff --check`
- CI and repeated ECS testing deployments
