### PR TITLE
Map new-CMS comprehension questions as numerical

### DIFF
--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -15,7 +15,8 @@ Contract (locked with the CMS owner — see task lms-cms-tests):
   the structure (subjects -> sections -> compulsory/optional problem refs) and marks at
   four levels (test / subject / section / problem). `problems` is a flat list of
   fully-resolved problems (text, options, answer, paragraph) joined to their refs by id.
-- Answers are 1-based option numbers; the quiz engine wants 0-based indices.
+- Choice answers are 1-based option numbers; the quiz engine wants 0-based indices.
+  Numerical and comprehension answers are numeric values.
 - Marks cascade problem-ref -> section -> subject -> test; the lowest level that sets
   marks wins. `pos_marks[0]` -> correct, `neg_marks[0]` -> wrong (as a negative).
 
@@ -39,6 +40,9 @@ Deliberate divergences from legacy (new-CMS data makes these strictly better):
 - NUMERICAL RANGE [low, high] stores the midpoint (low+high)/2 (the engine grades numerics
   with a fixed tolerance, so the midpoint is the least-biased point answer), not the low
   bound. True range grading is a later engine change.
+- COMPREHENSION problems are numerical-answer questions in the new CMS. Their paragraph
+  is inlined into the question text and their answer is mapped to numerical-integer or
+  numerical-float. The legacy CMS's single-choice comprehension contract is unchanged.
 
 Unknown problem subtypes fail the ingestion (like legacy's ValueError) rather than being
 silently mapped to single-choice — a wrong question type in a live quiz is worse than a
@@ -54,15 +58,14 @@ from settings import Settings
 
 settings = Settings()
 
-# CMS problem subtype -> quiz-engine question type. numerical_answer / integer_type
-# resolve to numerical-integer/float at map time based on the answer value.
+# CMS choice subtype -> quiz-engine question type. Numerical subtypes resolve to
+# numerical-integer/float at map time based on the answer value.
 CHOICE_TYPE_MAP = {
     "mcq_single_answer": "single-choice",
     "mcq_multiple_answer": "multi-choice",
     "matrix_match": "single-choice",  # single-answer; table baked into the question HTML
-    "comprehension": "single-choice",  # 1:1, paragraph self-carried on the problem
 }
-NUMERIC_SUBTYPES = ("numerical_answer", "integer_type")
+NUMERIC_SUBTYPES = ("numerical_answer", "integer_type", "comprehension")
 
 # Instruction blurbs shown at the top of a question set, keyed on the set's question type
 # (ported from QuizInterface.QUESTION_SET_TYPE_INSTRUCTION_MAPPING).
@@ -200,9 +203,9 @@ def _map_problem(
         },
     }
 
-    # numerical_answer and integer_type are both free-numeric-entry (no options); the CMS
-    # stores the answer as a single value or a [low, high] range. Map both to
-    # numerical-integer/float from the answer value.
+    # Numerical, integer, and new-CMS comprehension problems are free-numeric-entry (no
+    # options); the CMS stores the answer as a single value or a [low, high] range. Map
+    # them to numerical-integer/float from the answer value.
     if subtype in NUMERIC_SUBTYPES:
         if not answers:
             warnings.append(
@@ -248,16 +251,22 @@ def _numerical_answer(answers: List[Any], problem_id: Any, warnings: List[str]):
     to its midpoint (the engine grades numerics with a fixed tolerance, so the midpoint is
     the least-biased point answer); a single value is used as-is. Returns int or float.
     """
-    if len(answers) >= 2 and str(answers[0]) != str(answers[1]):
-        low, high = float(answers[0]), float(answers[1])
-        midpoint = (low + high) / 2
-        warnings.append(
-            f"problem {problem_id}: numerical range [{answers[0]}, {answers[1]}] stored as "
-            f"midpoint {midpoint} (engine grades a point +/- tolerance, not a range)"
-        )
-        return midpoint if midpoint != int(midpoint) else int(midpoint)
-    value = str(answers[0])
-    return float(value) if "." in value else int(value)
+    try:
+        if len(answers) >= 2 and str(answers[0]) != str(answers[1]):
+            low, high = float(answers[0]), float(answers[1])
+            midpoint = (low + high) / 2
+            warnings.append(
+                f"problem {problem_id}: numerical range [{answers[0]}, {answers[1]}] "
+                f"stored as midpoint {midpoint} (engine grades a point +/- tolerance, "
+                "not a range)"
+            )
+            return midpoint if midpoint != int(midpoint) else int(midpoint)
+        value = str(answers[0])
+        return float(value) if "." in value else int(value)
+    except (TypeError, ValueError) as exc:
+        raise CmsIngestError(
+            f"problem {problem_id}: invalid numerical answer {answers!r}"
+        ) from exc
 
 
 def _partial_scheme(max_options: int) -> List[Dict[str, Any]]:

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -272,7 +272,7 @@ class TestCmsMapper(unittest.TestCase):
         self.assertEqual(question["type"], "numerical-float")
         self.assertEqual(question["correct_answer"], 5.5)
 
-    def test_comprehension_inlines_paragraph(self):
+    def test_comprehension_inlines_paragraph_and_maps_numerical_answer(self):
         assembled = _test_with_problems(
             problems=[
                 _problem(
@@ -280,8 +280,8 @@ class TestCmsMapper(unittest.TestCase):
                     "comprehension",
                     {
                         "text": "Q on passage",
-                        "options": ["A", "B"],
-                        "answer": ["1"],
+                        "options": None,
+                        "answer": ["24.00"],
                         "solutions": [],
                     },
                     paragraph={"id": 9, "body": "PASSAGE. "},
@@ -300,8 +300,39 @@ class TestCmsMapper(unittest.TestCase):
 
         quiz, warnings = map_cms_test_to_quiz(assembled)
         question = quiz["question_sets"][0]["questions"][0]
-        self.assertEqual(question["type"], "single-choice")
+        self.assertEqual(question["type"], "numerical-float")
+        self.assertEqual(question["correct_answer"], 24.0)
+        self.assertEqual(question["options"], [])
         self.assertTrue(question["text"].startswith("PASSAGE. "))
+
+    def test_invalid_comprehension_answer_names_problem(self):
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    801,
+                    "comprehension",
+                    {
+                        "text": "Q on passage",
+                        "options": None,
+                        "answer": ["not-a-number"],
+                        "solutions": [],
+                    },
+                    paragraph={"id": 9, "body": "PASSAGE. "},
+                )
+            ],
+            sections=[
+                {
+                    "type": "comprehension",
+                    "name": "",
+                    "compulsory": {
+                        "problems": [{"id": 801, "pos_marks": [4], "neg_marks": [1]}]
+                    },
+                }
+            ],
+        )
+
+        with self.assertRaisesRegex(CmsIngestError, "problem 801"):
+            map_cms_test_to_quiz(assembled)
 
     def test_marks_cascade_from_section_when_problem_ref_unset(self):
         assembled = _test_with_problems(


### PR DESCRIPTION
## What changed

- Map new-CMS `comprehension` problems through the existing numerical-answer conversion instead of forcing `single-choice`.
- Preserve the comprehension paragraph in the question text and infer `numerical-integer` or `numerical-float` from the CMS answer.
- Raise a problem-specific `CmsIngestError` for malformed numerical answers so `/quiz/from-cms` returns a useful 502 instead of a generic 500.
- Replace the old single-choice comprehension test and add malformed-answer coverage.

## Why

New-CMS test 5445, problem 5446 is a comprehension problem with no options and answer `24.00`. The mapper treated every comprehension as single-choice and attempted `int("24.00") - 1`, causing `/quiz/from-cms` to return 500 and blocking session creation.

The engine stores the mapped question as `numerical-float`, so the existing sessionCreator, quiz-backend scoring, quizzes ETL scoring, models, exports, and frontend numerical paths require no changes. Legacy-CMS `comprehension_type` behavior remains untouched.

## Validation

- `python -m unittest tests/test_cms_ingest.py` — 16 passed
- Pre-commit hooks — all passed, including Black and flake8
- Read-only validation against real CMS test 5445: problem 5446 maps to `numerical-float`, correct answer `24.0`, empty options, paragraph preserved, and passes the Quiz model