### PR TITLE
cms ingest: set question metadata.chapter from assembled payload

### DIFF
--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -155,12 +155,29 @@ def _solutions(meta_data: Dict[str, Any]) -> List[str]:
     return out
 
 
+def _chapter_name(problem: Dict[str, Any]) -> Optional[str]:
+    """The assembled problem's `chapter_name` is a multilingual list
+    ([{"chapter": .., "lang_code": ..}]); return the English chapter name.
+
+    The downstream quiz-results ETL groups question responses by this chapter
+    name to build chapter-level analytics, so it must be a plain string.
+    """
+    entries = problem.get("chapter_name") or []
+    for entry in entries:
+        if entry.get("lang_code") == "en" and entry.get("chapter"):
+            return entry["chapter"]
+    return (entries[0].get("chapter") or None) if entries else None
+
+
 def _problem_metadata(problem: Dict[str, Any], subject_name: str) -> Dict[str, Any]:
     return {
         # subject_name is the plain, resolved subject name from the test structure;
         # the problem's own `Subject.name` is a multilingual list, so we don't use it.
         "subject": subject_name or None,
         "grade": str(problem["grade_id"]) if problem.get("grade_id") else None,
+        # chapter (name) mirrors subject: the assembled payload gives a multilingual
+        # list, flattened to the English name; chapter_id rides alongside it.
+        "chapter": _chapter_name(problem),
         "chapter_id": str(problem["chapter_id"]) if problem.get("chapter_id") else None,
         "topic_id": str(problem["topic_id"]) if problem.get("topic_id") else None,
         "difficulty": problem.get("difficulty_level") or None,

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -98,6 +98,76 @@ class TestCmsMapper(unittest.TestCase):
         self.assertEqual(quiz["max_marks"], 4)
         self.assertEqual(quiz["num_graded_questions"], 1)
 
+    def test_chapter_name_mapped_from_assembled_payload(self):
+        # The assembled problem carries chapter_name (multilingual list) + chapter_id;
+        # both must land on question metadata so chapter-level analytics can be built.
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {
+                        "text": "Q?",
+                        "options": ["A", "B", "C", "D"],
+                        "answer": ["1"],
+                        "solutions": [{"type": "text", "value": ""}],
+                    },
+                    chapter_id=34,
+                    chapter_name=[
+                        {"chapter": "मोल अवधारणा", "lang_code": "hi"},
+                        {"chapter": "Mole Concept", "lang_code": "en"},
+                    ],
+                )
+            ],
+            sections=[
+                {
+                    "type": "mcq_single_answer",
+                    "name": "",
+                    "compulsory": {
+                        "problems": [{"id": 506, "pos_marks": [4], "neg_marks": [1]}]
+                    },
+                }
+            ],
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+        meta = quiz["question_sets"][0]["questions"][0]["metadata"]
+        # picks the English name out of the multilingual list, not the first entry
+        self.assertEqual(meta["chapter"], "Mole Concept")
+        self.assertEqual(meta["chapter_id"], "34")
+
+    def test_missing_chapter_is_none(self):
+        # A problem with no chapter_name must leave chapter None (no crash) — the ETL
+        # fallback (etl-data-flow PR #116) resolves it at sync time in that case.
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {
+                        "text": "Q?",
+                        "options": ["A", "B", "C", "D"],
+                        "answer": ["1"],
+                        "solutions": [{"type": "text", "value": ""}],
+                    },
+                )
+            ],
+            sections=[
+                {
+                    "type": "mcq_single_answer",
+                    "name": "",
+                    "compulsory": {
+                        "problems": [{"id": 506, "pos_marks": [4], "neg_marks": [1]}]
+                    },
+                }
+            ],
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+        meta = quiz["question_sets"][0]["questions"][0]["metadata"]
+        self.assertIsNone(meta["chapter"])
+        self.assertIsNone(meta["chapter_id"])
+
     def test_multi_choice_partial_ladder(self):
         assembled = _test_with_problems(
             problems=[


### PR DESCRIPTION
## Problem

nex-gen-cms questions were landing in the quiz Mongo `questions` collection with `metadata.chapter = null`. `_problem_metadata` set `chapter_id` but never the chapter **name**. The downstream quiz-results ETL groups question responses by the chapter **name** (`groupby([..., "chapter"])`), so **every nex-gen-cms `chapter_test` produced empty chapter-level analytics** (and, before an ETL empty-frame guard, crashed the worker).

Scale: 0 of ~26k nex-gen-cms question-level rows had a chapter; ~68 sessions affected and growing.

## Fix

The assembled `/api/service/test` payload already carries chapter per problem — **verified live against staging** (`test 1700`: `chapter_id` + `chapter_name` on all 25/25 problems), and at the db-service source (`resource/test/{id}/problems`). So no nex-gen-cms change is needed.

- Add `_chapter_name()` to flatten the multilingual `chapter_name` list (`[{"chapter": "Mole Concept", "lang_code": "en"}]`) to the English name — mirrors the existing `_test_name()` helper.
- Set `metadata.chapter` from it in `_problem_metadata`. `chapter_id` was already read.

## Testing

- `pytest app/tests/test_cms_ingest.py` → 18 passed, including two new cases:
  - `test_chapter_name_mapped_from_assembled_payload` — picks the English name out of a multi-lang list; `chapter_id` set.
  - `test_missing_chapter_is_none` — no `chapter_name` → `chapter`/`chapter_id` stay `None`, no crash.
- Verified the real ingest contract end-to-end: staging `/api/service/test` returns chapter for every problem.

## Context

Complements the ETL-side fallback in **etl-data-flow** ([PR #116](https://github.com/avantifellows/etl-data-flow/pull/116)), which resolves chapter from AF DB when `metadata.chapter` is missing. This PR fixes the **source** so new quizzes carry chapter natively; once deployed, the ETL fallback becomes belt-and-suspenders and can retire. Tracked as DEBT D25.

Only affects **new** quizzes generated from CMS; already-created sessions rely on the ETL fallback + a re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)