### PR TITLE
Merge main into release: CMS quiz-session settings, patch and regenerate

### DIFF
--- a/.github/workflows/biweekly-release.yml
+++ b/.github/workflows/biweekly-release.yml
@@ -1,9 +1,11 @@
 name: Biweekly Release
 
-# Biweekly LLM-written release notes (issue #219).
-# GitHub cron can't express "every 14 days", so a weekly cron fires and the
-# gate step runs the job only on odd epoch-weeks: Jul 27 2026, Aug 10, … .
-# Manual runs bypass the gate. Local run:
+# Biweekly LLM-written release notes (see avantifellows/af_lms#219 for the
+# decision record). Org repos post in staggered groups, max 3 per day:
+# this repo is in the learning-and-assessment group.
+# The weekly cron fires on the group's weekday; the gate step runs the job
+# only when a whole number of 14-day cycles has passed since the group's
+# anchor date. Manual runs bypass the gate. Local run:
 #   act workflow_dispatch -W .github/workflows/biweekly-release.yml \
 #     --secret-file .secrets --input provider=openrouter \
 #     -P ubuntu-latest=catthehacker/ubuntu:act-latest
@@ -27,10 +29,14 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: "30 3 * * 1" # Mondays 09:00 IST; gate skips every other week
+    - cron: "30 3 * * 1" # Mondays 09:00 IST; gate enforces the 14-day cycle
 
 permissions:
   contents: write
+
+env:
+  # Epoch-day of this group's first scheduled run (2026-07-20).
+  RELEASE_ANCHOR_DAY: "20654"
 
 jobs:
   biweekly-release:
@@ -43,10 +49,10 @@ jobs:
         id: gate
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || \
-             [ $(( $(date +%s) / 86400 / 7 % 2 )) -eq 1 ]; then
+             [ $(( ($(date +%s) / 86400 - ${{ env.RELEASE_ANCHOR_DAY }}) % 14 )) -eq 0 ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Off week — the biweekly cadence runs next Monday. Skipping."
+            echo "Off week — this repo's 14-day cycle runs next week. Skipping."
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/biweekly-release.yml
+++ b/.github/workflows/biweekly-release.yml
@@ -113,19 +113,25 @@ jobs:
           echo "--- Generated notes ---"
           cat out/notes.md
 
-      - name: Create draft release
+      - name: Create release
         id: release
         if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
         run: |
           TAG="${{ steps.gather.outputs.tag }}"
-          # Idempotent re-runs: replace an existing draft for the same tag.
-          EXISTING=$(gh release list --repo "$GH_REPO" --json tagName,isDraft \
-            --jq ".[] | select(.tagName == \"$TAG\" and .isDraft) | .tagName")
-          [ -n "$EXISTING" ] && gh release delete "$TAG" --repo "$GH_REPO" --yes
-          URL=$(gh release create "$TAG" --repo "$GH_REPO" --draft \
-            --title "Release $TAG (${{ steps.gather.outputs.range }})" --notes-file out/notes.md)
+          TITLE="Release $TAG (${{ steps.gather.outputs.range }})"
+          # Idempotent re-runs: refresh a published release's notes in place;
+          # replace a leftover draft with the same tag.
+          STATE=$(gh release view "$TAG" --repo "$GH_REPO" --json isDraft --jq .isDraft 2>/dev/null || echo "absent")
+          if [ "$STATE" = "false" ]; then
+            gh release edit "$TAG" --repo "$GH_REPO" --title "$TITLE" --notes-file out/notes.md
+            URL=$(gh release view "$TAG" --repo "$GH_REPO" --json url --jq .url)
+          else
+            [ "$STATE" = "true" ] && gh release delete "$TAG" --repo "$GH_REPO" --yes
+            URL=$(gh release create "$TAG" --repo "$GH_REPO" \
+              --title "$TITLE" --notes-file out/notes.md)
+          fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "Draft release: $URL"
+          echo "Release: $URL"
 
       - name: Post to Discord
         if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
@@ -133,7 +139,7 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           jq -n \
-            --arg title "${GH_REPO#*/} — release ${{ steps.gather.outputs.tag }} · ${{ steps.gather.outputs.range }} (draft)" \
+            --arg title "${GH_REPO#*/} — release ${{ steps.gather.outputs.tag }} · ${{ steps.gather.outputs.range }}" \
             --arg url "${{ steps.release.outputs.url }}" \
             --arg desc "$(head -c 4000 out/notes.md)" \
             '{embeds: [{title: $title, url: $url, description: $desc, color: 5793266}]}' \

--- a/.github/workflows/biweekly-release.yml
+++ b/.github/workflows/biweekly-release.yml
@@ -1,0 +1,134 @@
+name: Biweekly Release
+
+# Biweekly LLM-written release notes (issue #219).
+# GitHub cron can't express "every 14 days", so a weekly cron fires and the
+# gate step runs the job only on odd epoch-weeks: Jul 27 2026, Aug 10, … .
+# Manual runs bypass the gate. Local run:
+#   act workflow_dispatch -W .github/workflows/biweekly-release.yml \
+#     --secret-file .secrets --input provider=openrouter \
+#     -P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: LLM provider
+        type: choice
+        options: [anthropic, openrouter]
+        default: anthropic
+      window_days:
+        description: Days of history to include
+        default: "14"
+      thinking:
+        description: Thinking effort (off/minimal/low/medium/high/xhigh/max)
+        default: medium
+      dry_run:
+        description: Generate notes but skip the release and Discord post
+        type: boolean
+        default: false
+  schedule:
+    - cron: "30 3 * * 1" # Mondays 09:00 IST; gate skips every other week
+
+permissions:
+  contents: write
+
+jobs:
+  biweekly-release:
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Biweekly gate
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || \
+             [ $(( $(date +%s) / 86400 / 7 % 2 )) -eq 1 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Off week — the biweekly cadence runs next Monday. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.run == 'true'
+
+      - name: Ensure gh and jq (preinstalled on hosted runners; act image lacks gh)
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          command -v jq >/dev/null || { sudo apt-get update -qq && sudo apt-get install -y -qq jq; }
+          if ! command -v gh >/dev/null; then
+            curl -fsSL https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_linux_amd64.tar.gz | tar -xz -C /tmp
+            sudo mv /tmp/gh_*/bin/gh /usr/local/bin/gh
+          fi
+
+      - name: Gather the release window's work
+        id: gather
+        if: steps.gate.outputs.run == 'true'
+        env:
+          WINDOW_DAYS: ${{ inputs.window_days || '14' }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: bash release-notes/gather.sh
+
+      - name: Set up Node
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install pi
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        # Pinned: the project moved from @mariozechner/pi-coding-agent (stuck at
+        # 0.73.x, breaks on claude-sonnet-5 thinking) to @earendil-works.
+        # 0.80.3+ speaks Anthropic adaptive thinking. --force overwrites a stale
+        # `pi` bin left in act's reused tool cache by the old package name.
+        run: npm install -g --force @earendil-works/pi-coding-agent@0.80.10
+
+      - name: Generate release notes
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          PROVIDER: ${{ inputs.provider || 'anthropic' }}
+          THINKING: ${{ inputs.thinking || 'medium' }}
+        run: |
+          if [ "$PROVIDER" = "openrouter" ]; then
+            MODEL="deepseek/deepseek-v4-flash"
+          else
+            MODEL="claude-sonnet-5"
+          fi
+          pi -p --no-session --no-tools --no-skills --no-extensions --no-context-files \
+             --thinking "$THINKING" --provider "$PROVIDER" --model "$MODEL" \
+             --system-prompt "$(cat release-notes/system-prompt.md)" \
+             "$(cat out/context.md)" > out/notes.md
+          test -s out/notes.md
+          printf '\n' >> out/notes.md
+          cat out/changelog.md >> out/notes.md
+          echo "--- Generated notes ---"
+          cat out/notes.md
+
+      - name: Create draft release
+        id: release
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
+        run: |
+          TAG="${{ steps.gather.outputs.tag }}"
+          # Idempotent re-runs: replace an existing draft for the same tag.
+          EXISTING=$(gh release list --repo "$GH_REPO" --json tagName,isDraft \
+            --jq ".[] | select(.tagName == \"$TAG\" and .isDraft) | .tagName")
+          [ -n "$EXISTING" ] && gh release delete "$TAG" --repo "$GH_REPO" --yes
+          URL=$(gh release create "$TAG" --repo "$GH_REPO" --draft \
+            --title "Release $TAG (${{ steps.gather.outputs.range }})" --notes-file out/notes.md)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Draft release: $URL"
+
+      - name: Post to Discord
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          jq -n \
+            --arg title "${GH_REPO#*/} — release ${{ steps.gather.outputs.tag }} · ${{ steps.gather.outputs.range }} (draft)" \
+            --arg url "${{ steps.release.outputs.url }}" \
+            --arg desc "$(head -c 4000 out/notes.md)" \
+            '{embeds: [{title: $title, url: $url, description: $desc, color: 5793266}]}' \
+          | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"

--- a/app/models.py
+++ b/app/models.py
@@ -123,7 +123,10 @@ class QuizMetadata(BaseModel):
     topic: Optional[str]
     source: Optional[str]
     source_id: Optional[str]
-    session_end_time: Optional[str]  # format: %Y-%m-%d %I:%M:%S %p
+    # Answer-visibility time (ISO wall-clock): when review_immediate is false, the frontend
+    # defers answer review until now > this. Derived as session window end + quiz duration
+    # (services.quiz_time), so students still mid-test don't get early access.
+    session_end_time: Optional[str]
     next_step_url: Optional[str]  # URL to redirect to after quiz completion
     next_step_text: Optional[str]  # Text to display on the next step button
     next_step_autostart: Optional[bool] = False  # Whether next step should auto-start

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import APIRouter, status, HTTPException, Query
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -221,6 +223,78 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
             "source_id": str(request.test_id),
             "warnings": warnings,
         },
+    )
+
+
+class QuizPatchRequest(BaseModel):
+    """Body for PATCH /quiz/{quiz_id} — field-scoped update of the session-editable
+    settings on an existing quiz doc. Only the fields that are sent are changed; the
+    LMS session-edit flow decides which to send."""
+
+    title: Optional[str] = None
+    shuffle: Optional[bool] = None
+    show_scores: Optional[bool] = None
+    # "show answers immediately after submission" (off during concurrent testing)
+    review_immediate: Optional[bool] = None
+    # metadata.session_end_time, format: %Y-%m-%d %I:%M:%S %p
+    session_end_time: Optional[str] = None
+
+
+@router.patch("/{quiz_id}")
+async def patch_quiz(quiz_id: str, request: QuizPatchRequest):
+    """Patch session-editable settings on an existing quiz in place (same _id).
+
+    Called by the LMS when a quiz session is edited so the display/scoring settings
+    on the quiz doc stay in sync, without rebuilding the quiz or its questions.
+    """
+    quiz_collection = client.quiz.quizzes
+
+    existing = quiz_collection.find_one({"_id": quiz_id}, {"_id": 1, "metadata": 1})
+    if existing is None:
+        logger.warning(f"Requested quiz {quiz_id} not found for patch")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"quiz {quiz_id} not found"
+        )
+
+    set_ops = {}
+    updated = []
+    for field in ("title", "shuffle", "show_scores", "review_immediate"):
+        value = getattr(request, field)
+        if value is not None:
+            set_ops[field] = value
+            updated.append(field)
+    if request.session_end_time is not None:
+        updated.append("session_end_time")
+        # A dotted $set ("metadata.session_end_time") raises when metadata is
+        # explicitly null (Mongo can't traverse a null intermediate), so write the
+        # whole subdoc in that case. An absent metadata is fine with dot-notation.
+        if existing.get("metadata") is None:
+            set_ops["metadata"] = {"session_end_time": request.session_end_time}
+        else:
+            set_ops["metadata.session_end_time"] = request.session_end_time
+
+    if not set_ops:
+        return JSONResponse(
+            status_code=status.HTTP_200_OK, content={"id": quiz_id, "updated": []}
+        )
+
+    result = quiz_collection.update_one({"_id": quiz_id}, {"$set": set_ops})
+    if not result.acknowledged:
+        error_message = f"Failed to patch quiz {quiz_id}"
+        logger.error(error_message)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error_message
+        )
+    if result.matched_count == 0:
+        # Deleted between the existence check and the write.
+        logger.warning(f"Quiz {quiz_id} vanished before patch could apply")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"quiz {quiz_id} not found"
+        )
+    logger.info(f"Patched quiz {quiz_id}: {updated}")
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"id": quiz_id, "updated": updated},
     )
 
 

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -13,6 +13,7 @@ from services.cms_ingest import (
     map_cms_test_to_quiz,
     CmsIngestError,
 )
+from services.quiz_time import answer_visibility_end_time
 from logger_config import get_logger
 
 router = APIRouter(prefix="/quiz", tags=["Quiz"])
@@ -87,6 +88,44 @@ def update_quiz_for_backwards_compatibility(quiz_collection, quiz_id, quiz):
     logger.info("Quiz updated for backwards compatibility")
 
 
+def _aggregate_question_set_subset(question_set_id) -> list:
+    """Build the question list a quiz doc stores for one set: the first `subset_size`
+    questions in full detail plus the rest projected to grading-only fields. The questions
+    themselves live in full in the `questions` collection; this is the denormalized subset
+    embedded on the quiz. Shared by create and regenerate so both produce the same shape.
+
+    Questions are ordered by `_id`, which preserves authored order because ids are assigned
+    in list order at insert time — the create and regenerate paths rely on this to keep the
+    embedded subset aligned with the authored question order.
+    """
+    subset_with_details = client.quiz.questions.aggregate(
+        [
+            {"$match": {"question_set_id": question_set_id}},
+            {"$sort": {"_id": 1}},
+            {"$limit": settings.subset_size},
+        ]
+    )
+    subset_without_details = client.quiz.questions.aggregate(
+        [
+            {"$match": {"question_set_id": question_set_id}},
+            {"$sort": {"_id": 1}},
+            {"$skip": settings.subset_size},
+            {
+                "$project": {
+                    "graded": 1,
+                    "force_correct": 1,
+                    "type": 1,
+                    "matrix_rows": 1,
+                    "correct_answer": 1,
+                    "question_set_id": 1,
+                    "marking_scheme": 1,
+                }
+            },
+        ]
+    )
+    return list(subset_with_details) + list(subset_without_details)
+
+
 def _insert_quiz_with_questions(quiz: dict) -> str:
     """Insert a quiz (already jsonable-encoded) and its questions into Mongo, returning
     the new quiz id. Shared by the direct create endpoint and the CMS-ingest endpoint.
@@ -121,35 +160,9 @@ def _insert_quiz_with_questions(quiz: dict) -> str:
                 detail=error_message,
             )
 
-        subset_with_details = client.quiz.questions.aggregate(
-            [
-                {"$match": {"question_set_id": question_set["_id"]}},
-                {"$sort": {"_id": 1}},
-                {"$limit": settings.subset_size},
-            ]
-        )
-
-        subset_without_details = client.quiz.questions.aggregate(
-            [
-                {"$match": {"question_set_id": question_set["_id"]}},
-                {"$sort": {"_id": 1}},
-                {"$skip": settings.subset_size},
-                {
-                    "$project": {
-                        "graded": 1,
-                        "force_correct": 1,
-                        "type": 1,
-                        "matrix_rows": 1,
-                        "correct_answer": 1,
-                        "question_set_id": 1,
-                        "marking_scheme": 1,
-                    }
-                },
-            ]
-        )
-
-        aggregated_questions = list(subset_with_details) + list(subset_without_details)
-        quiz["question_sets"][question_set_index]["questions"] = aggregated_questions
+        quiz["question_sets"][question_set_index][
+            "questions"
+        ] = _aggregate_question_set_subset(question_set["_id"])
 
     new_quiz_result = client.quiz.quizzes.insert_one(quiz)
     if not new_quiz_result.acknowledged:
@@ -164,12 +177,19 @@ def _insert_quiz_with_questions(quiz: dict) -> str:
 
 
 class CmsQuizIngestRequest(BaseModel):
-    """Body for POST /quiz/from-cms — identifies a chapter test in the new CMS."""
+    """Body for POST /quiz/from-cms and PUT /quiz/{id}/from-cms — identifies a chapter test
+    in the new CMS, plus the optional session window end used to derive answer-visibility.
+    """
 
     test_id: int
     curriculum_id: int
     grade_id: int
     quiz_type: str = QuizType.assessment.value
+    # Raw session window-end as an ISO wall-clock string (IST), e.g. "2026-04-15T14:00:00".
+    # The stored metadata.session_end_time is this PLUS the quiz duration (see
+    # services.quiz_time) so students still mid-test don't get early answer access. Optional:
+    # untimed quizzes / callers that don't gate review can omit it.
+    session_end_time: Optional[str] = None
 
     class Config:
         schema_extra = {
@@ -178,6 +198,7 @@ class CmsQuizIngestRequest(BaseModel):
                 "curriculum_id": 1,
                 "grade_id": 1,
                 "quiz_type": "assessment",
+                "session_end_time": "2026-04-15T14:00:00",
             }
         }
 
@@ -208,6 +229,16 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
         logger.error(f"CMS ingest failed for test {request.test_id}: {exc}")
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
 
+    # Answer-visibility time = window end + quiz duration (see services.quiz_time). Set here
+    # at create so a CMS session with review_immediate=false defers review correctly; without
+    # it the quiz doc has no session_end_time and the frontend never gates review.
+    if request.session_end_time:
+        quiz_dict.setdefault("metadata", {})[
+            "session_end_time"
+        ] = answer_visibility_end_time(
+            request.session_end_time, quiz_dict.get("time_limit")
+        )
+
     # Validate + fill defaults (ids, etc.) through the same model the direct endpoint uses.
     quiz = jsonable_encoder(Quiz(**quiz_dict))
     quiz_id = _insert_quiz_with_questions(quiz)
@@ -226,6 +257,167 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
     )
 
 
+# Session-editable settings that live on the quiz doc (not the CMS source). Regenerate must
+# preserve these across a re-ingest — they were set by the LMS session-edit flow, not by the
+# test content, so re-pulling the test must not reset them.
+_SESSION_EDITABLE_QUIZ_FIELDS = ("title", "shuffle", "show_scores", "review_immediate")
+_SESSION_EDITABLE_METADATA_FIELDS = ("grade", "single_page_header_text")
+
+
+@router.put("/{quiz_id}/from-cms")
+async def regenerate_quiz_from_cms(quiz_id: str, request: CmsQuizIngestRequest):
+    """Re-ingest the (corrected) CMS test into an EXISTING quiz in place: the quiz keeps its
+    _id and every question-set / question _id, so the session and any submitted attempts stay
+    linked. Refreshes question content, answer key, marking, marks, timing and content
+    metadata (test_format/subject); preserves the session-editable settings on the quiz doc
+    (title, shuffle, show_scores, review_immediate, grade, single_page_header_text, and
+    session_end_time unless a new window end is supplied). Mirrors the legacy sessionCreator
+    regenerate path (patch_quiz_in_mongo, Mode B).
+
+    Refuses with 409 if the regenerated test's structure differs from the existing quiz
+    (different number of question sets, or a different question count in any set): the
+    positional _id mapping that keeps attempts linked would otherwise silently misalign.
+    """
+    logger.info(
+        f"CMS regenerate: quiz {quiz_id} from test {request.test_id} "
+        f"(curriculum {request.curriculum_id}, grade {request.grade_id})"
+    )
+    quiz_collection = client.quiz.quizzes
+    existing = quiz_collection.find_one({"_id": quiz_id})
+    if existing is None:
+        logger.warning(f"Requested quiz {quiz_id} not found for regenerate")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"quiz {quiz_id} not found"
+        )
+
+    try:
+        assembled = fetch_assembled_test(
+            request.test_id, request.curriculum_id, request.grade_id
+        )
+        new_quiz, warnings = map_cms_test_to_quiz(
+            assembled, quiz_type=request.quiz_type
+        )
+    except CmsIngestError as exc:
+        logger.error(f"CMS regenerate failed for test {request.test_id}: {exc}")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+    # Validate + fill defaults through the same model create uses (fresh set/question ids,
+    # which we then overwrite positionally with the existing ones below).
+    new_quiz = jsonable_encoder(Quiz(**new_quiz))
+
+    # The regenerated test must line up POSITIONALLY with the existing quiz, or the _id
+    # reuse below would remap answer keys onto the wrong questions and silently mis-score
+    # submitted attempts. Validate fully BEFORE any write: same set count, same per-set
+    # question count, and — the subtle one — the same question at each position. A
+    # delete+add or a reorder keeps the counts but changes identity; anchor on the CMS
+    # source_id (present on both sides for CMS quizzes) to catch it. Cache the fetched
+    # existing question docs so the write pass doesn't re-read them.
+    old_sets = existing.get("question_sets") or []
+    new_sets = new_quiz["question_sets"]
+    mismatch = None
+    existing_questions = {}  # (set_index, question_index) -> full existing question doc
+    if len(new_sets) != len(old_sets):
+        mismatch = f"question-set count changed ({len(old_sets)} -> {len(new_sets)})"
+    else:
+        for i, (old_s, new_s) in enumerate(zip(old_sets, new_sets)):
+            old_qs = old_s.get("questions") or []
+            new_qs = new_s.get("questions") or []
+            if len(old_qs) != len(new_qs):
+                mismatch = f"question count in set {i} changed ({len(old_qs)} -> {len(new_qs)})"
+                break
+            for j, (old_q, new_q) in enumerate(zip(old_qs, new_qs)):
+                existing_q = client.quiz.questions.find_one({"_id": old_q["_id"]}) or {}
+                existing_questions[(i, j)] = existing_q
+                old_src = existing_q.get("source_id")
+                new_src = new_q.get("source_id")
+                if old_src and new_src and str(old_src) != str(new_src):
+                    mismatch = (
+                        f"question {j} in set {i} is a different problem "
+                        f"(source_id {old_src} -> {new_src})"
+                    )
+                    break
+            if mismatch:
+                break
+    if mismatch:
+        logger.warning(f"Regenerate refused for quiz {quiz_id}: {mismatch}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"regenerated test differs from the existing quiz: {mismatch}. Regenerate "
+                "preserves attempt links by position and cannot remap a reshaped or "
+                "reordered test; create a new session for it instead."
+            ),
+        )
+
+    # Preserve the quiz _id and every set/question _id positionally, and refresh each question
+    # doc in the questions collection in place (back-filling any keys the new mapping drops).
+    # NOTE: this is not atomic — questions are replaced before the quiz doc, so a mid-loop
+    # failure leaves refreshed questions with a stale embedded grading subset. Tracked as debt
+    # (needs a replica-set transaction to fix); acceptable for a rare admin-triggered action.
+    new_quiz["_id"] = quiz_id
+    for i, new_s in enumerate(new_sets):
+        old_s = old_sets[i]
+        new_s["_id"] = old_s["_id"]
+        for j, new_q in enumerate(new_s["questions"]):
+            question_id = old_s["questions"][j]["_id"]
+            new_q["_id"] = question_id
+            new_q["question_set_id"] = new_s["_id"]
+            existing_q = existing_questions.get((i, j)) or {}
+            for key, value in existing_q.items():
+                if key not in new_q:
+                    new_q[key] = value
+            client.quiz.questions.replace_one({"_id": question_id}, new_q)
+        # Re-derive the embedded subset from the refreshed question docs.
+        new_s["questions"] = _aggregate_question_set_subset(new_s["_id"])
+
+    # Preserve session-editable settings the LMS set on the quiz doc (content comes from CMS).
+    for field in _SESSION_EDITABLE_QUIZ_FIELDS:
+        if field in existing:
+            new_quiz[field] = existing[field]
+
+    new_meta = new_quiz.get("metadata") or {}
+    old_meta = existing.get("metadata") or {}
+    for field in _SESSION_EDITABLE_METADATA_FIELDS:
+        if old_meta.get(field) is not None:
+            new_meta[field] = old_meta[field]
+    if request.session_end_time:
+        new_meta["session_end_time"] = answer_visibility_end_time(
+            request.session_end_time, new_quiz.get("time_limit")
+        )
+    elif old_meta.get("session_end_time") is not None:
+        new_meta["session_end_time"] = old_meta["session_end_time"]
+    new_quiz["metadata"] = new_meta
+
+    # Back-fill any other top-level keys the old doc carried but the new one lacks (legacy
+    # parity — don't drop engine-added fields).
+    for key, value in existing.items():
+        if key not in new_quiz:
+            new_quiz[key] = value
+
+    result = quiz_collection.replace_one({"_id": quiz_id}, new_quiz)
+    if not result.acknowledged:
+        error_message = f"Failed to regenerate quiz {quiz_id}"
+        logger.error(error_message)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error_message
+        )
+
+    if warnings:
+        logger.warning(
+            f"CMS regenerate for test {request.test_id} produced warnings: {warnings}"
+        )
+    logger.info(f"Regenerated quiz {quiz_id} from CMS test {request.test_id}")
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={
+            "id": quiz_id,
+            "source_id": str(request.test_id),
+            "warnings": warnings,
+            "regenerated": True,
+        },
+    )
+
+
 class QuizPatchRequest(BaseModel):
     """Body for PATCH /quiz/{quiz_id} — field-scoped update of the session-editable
     settings on an existing quiz doc. Only the fields that are sent are changed; the
@@ -236,7 +428,9 @@ class QuizPatchRequest(BaseModel):
     show_scores: Optional[bool] = None
     # "show answers immediately after submission" (off during concurrent testing)
     review_immediate: Optional[bool] = None
-    # metadata.session_end_time, format: %Y-%m-%d %I:%M:%S %p
+    # Raw session window-end (ISO wall-clock, e.g. "2026-04-15T14:00:00"). Stored as
+    # metadata.session_end_time PLUS the quiz duration (answer-visibility time); see
+    # services.quiz_time.
     session_end_time: Optional[str] = None
 
 
@@ -249,7 +443,9 @@ async def patch_quiz(quiz_id: str, request: QuizPatchRequest):
     """
     quiz_collection = client.quiz.quizzes
 
-    existing = quiz_collection.find_one({"_id": quiz_id}, {"_id": 1, "metadata": 1})
+    existing = quiz_collection.find_one(
+        {"_id": quiz_id}, {"_id": 1, "metadata": 1, "time_limit": 1}
+    )
     if existing is None:
         logger.warning(f"Requested quiz {quiz_id} not found for patch")
         raise HTTPException(
@@ -265,13 +461,18 @@ async def patch_quiz(quiz_id: str, request: QuizPatchRequest):
             updated.append(field)
     if request.session_end_time is not None:
         updated.append("session_end_time")
+        # Store the answer-visibility time (window end + quiz duration), reading the duration
+        # off the existing quiz doc — matches legacy sessionCreator; see services.quiz_time.
+        visibility_time = answer_visibility_end_time(
+            request.session_end_time, existing.get("time_limit")
+        )
         # A dotted $set ("metadata.session_end_time") raises when metadata is
         # explicitly null (Mongo can't traverse a null intermediate), so write the
         # whole subdoc in that case. An absent metadata is fine with dot-notation.
         if existing.get("metadata") is None:
-            set_ops["metadata"] = {"session_end_time": request.session_end_time}
+            set_ops["metadata"] = {"session_end_time": visibility_time}
         else:
-            set_ops["metadata.session_end_time"] = request.session_end_time
+            set_ops["metadata.session_end_time"] = visibility_time
 
     if not set_ops:
         return JSONResponse(

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -176,6 +176,16 @@ def _insert_quiz_with_questions(quiz: dict) -> str:
     return new_quiz_result.inserted_id
 
 
+# Display/scoring settings the LMS session form owns, stored on the quiz doc rather than
+# derived from the CMS test. Supplied on CREATE (see CmsQuizIngestRequest) and preserved
+# across a regenerate — a re-ingest refreshes content, never these.
+_SESSION_EDITABLE_QUIZ_SETTINGS = ("shuffle", "show_scores", "review_immediate")
+# ...plus the title, which regenerate must also keep (the LMS names the session, and the CMS
+# test name would otherwise clobber a renamed session). Not settable via the create body:
+# create takes the title straight from the mapped CMS test.
+_SESSION_EDITABLE_QUIZ_FIELDS = ("title",) + _SESSION_EDITABLE_QUIZ_SETTINGS
+
+
 class CmsQuizIngestRequest(BaseModel):
     """Body for POST /quiz/from-cms and PUT /quiz/{id}/from-cms — identifies a chapter test
     in the new CMS, plus the optional session window end used to derive answer-visibility.
@@ -191,6 +201,19 @@ class CmsQuizIngestRequest(BaseModel):
     # untimed quizzes / callers that don't gate review can omit it.
     session_end_time: Optional[str] = None
 
+    # Session-level display/scoring settings chosen by the PM in the LMS session form. The
+    # CMS test carries no notion of these, so the mapper emits hardcoded defaults
+    # (shuffle=False) and the Quiz model fills the rest (review_immediate/show_scores=True).
+    # Without them on CREATE, a PM who ticked "shuffle" got a quiz that never shuffled and
+    # one who unticked "show answers" got answers shown immediately, since the quiz-taking
+    # frontend reads all three off the quiz doc, not the session row. Omitted (None) means
+    # "leave the default" — on regenerate these are ignored in favour of the values already
+    # on the doc (see _SESSION_EDITABLE_QUIZ_FIELDS).
+    shuffle: Optional[bool] = None
+    show_scores: Optional[bool] = None
+    # "show answers immediately after submission" in the LMS form.
+    review_immediate: Optional[bool] = None
+
     class Config:
         schema_extra = {
             "example": {
@@ -199,6 +222,9 @@ class CmsQuizIngestRequest(BaseModel):
                 "grade_id": 1,
                 "quiz_type": "assessment",
                 "session_end_time": "2026-04-15T14:00:00",
+                "shuffle": True,
+                "show_scores": True,
+                "review_immediate": False,
             }
         }
 
@@ -239,6 +265,14 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
             request.session_end_time, quiz_dict.get("time_limit")
         )
 
+    # Apply the PM's session settings over the mapper's defaults. The quiz-taking frontend
+    # reads these off the quiz doc, so skipping them here silently discards the choice made
+    # in the LMS form. Only fields explicitly supplied are overridden.
+    for field in _SESSION_EDITABLE_QUIZ_SETTINGS:
+        value = getattr(request, field)
+        if value is not None:
+            quiz_dict[field] = value
+
     # Validate + fill defaults (ids, etc.) through the same model the direct endpoint uses.
     quiz = jsonable_encoder(Quiz(**quiz_dict))
     quiz_id = _insert_quiz_with_questions(quiz)
@@ -257,10 +291,6 @@ async def create_quiz_from_cms(request: CmsQuizIngestRequest):
     )
 
 
-# Session-editable settings that live on the quiz doc (not the CMS source). Regenerate must
-# preserve these across a re-ingest — they were set by the LMS session-edit flow, not by the
-# test content, so re-pulling the test must not reset them.
-_SESSION_EDITABLE_QUIZ_FIELDS = ("title", "shuffle", "show_scores", "review_immediate")
 _SESSION_EDITABLE_METADATA_FIELDS = ("grade", "single_page_header_text")
 
 

--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -155,12 +155,29 @@ def _solutions(meta_data: Dict[str, Any]) -> List[str]:
     return out
 
 
+def _chapter_name(problem: Dict[str, Any]) -> Optional[str]:
+    """The assembled problem's `chapter_name` is a multilingual list
+    ([{"chapter": .., "lang_code": ..}]); return the English chapter name.
+
+    The downstream quiz-results ETL groups question responses by this chapter
+    name to build chapter-level analytics, so it must be a plain string.
+    """
+    entries = problem.get("chapter_name") or []
+    for entry in entries:
+        if entry.get("lang_code") == "en" and entry.get("chapter"):
+            return entry["chapter"]
+    return (entries[0].get("chapter") or None) if entries else None
+
+
 def _problem_metadata(problem: Dict[str, Any], subject_name: str) -> Dict[str, Any]:
     return {
         # subject_name is the plain, resolved subject name from the test structure;
         # the problem's own `Subject.name` is a multilingual list, so we don't use it.
         "subject": subject_name or None,
         "grade": str(problem["grade_id"]) if problem.get("grade_id") else None,
+        # chapter (name) mirrors subject: the assembled payload gives a multilingual
+        # list, flattened to the English name; chapter_id rides alongside it.
+        "chapter": _chapter_name(problem),
         "chapter_id": str(problem["chapter_id"]) if problem.get("chapter_id") else None,
         "topic_id": str(problem["topic_id"]) if problem.get("topic_id") else None,
         "difficulty": problem.get("difficulty_level") or None,

--- a/app/services/quiz_time.py
+++ b/app/services/quiz_time.py
@@ -1,0 +1,94 @@
+"""
+Answer-visibility time computation for quiz sessions.
+
+The quiz-taking frontend defers answer/solution review until the wall-clock passes
+`quiz.metadata.session_end_time` (Player.vue, when review_immediate is false). To stop a
+student who is still mid-test from seeing answers, that stored time must be the moment the
+LAST possible attempt could finish: the session window end PLUS the quiz duration
+(`time_limit.max`), NOT the raw window end.
+
+This mirrors the legacy sessionCreator exactly (etl-data-flow
+flows/sessionCreator/SessionCreator.py `_quiz_answer_visibility_end_time`), which this
+service's create/patch/regenerate paths replace. Ported verbatim so a session edited or
+regenerated here stores the same value the legacy Lambda would have.
+"""
+
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+from logger_config import get_logger
+
+logger = get_logger()
+
+# Non-ISO wall-clock formats we accept, in addition to datetime.fromisoformat. The 12-hour
+# "%I:%M:%S %p" form is what the quiz doc has historically stored (and what the LMS emits
+# today), so it must parse or the duration offset would be silently dropped.
+_FALLBACK_FORMATS = ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %I:%M:%S %p")
+
+
+def parse_quiz_end_time(end_time: Any) -> Optional[datetime]:
+    """Parse a window-end value (ISO string, "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %I:%M:%S %p", or
+    datetime) into a naive datetime (tz stripped, microseconds zeroed). None if unparseable.
+    """
+    if not end_time:
+        return None
+
+    if isinstance(end_time, datetime):
+        parsed = end_time
+        if parsed.tzinfo is not None:
+            parsed = parsed.replace(tzinfo=None)
+        return parsed.replace(microsecond=0)
+
+    if not isinstance(end_time, str):
+        return None
+
+    normalized = end_time
+    if normalized.endswith("Z"):
+        normalized = normalized.replace("Z", "+00:00")
+
+    parsed = None
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        for fmt in _FALLBACK_FORMATS:
+            try:
+                parsed = datetime.strptime(normalized, fmt)
+                break
+            except ValueError:
+                continue
+    if parsed is None:
+        return None
+
+    if parsed.tzinfo is not None:
+        parsed = parsed.replace(tzinfo=None)
+
+    return parsed.replace(microsecond=0)
+
+
+def quiz_duration_seconds(time_limit: Any) -> int:
+    """The quiz duration in seconds from a time_limit {min, max} dict. 0 if unset/untimed."""
+    if not isinstance(time_limit, dict):
+        return 0
+    try:
+        return int(time_limit.get("max") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def answer_visibility_end_time(window_end: Any, time_limit: Any) -> Optional[str]:
+    """Answer-visibility moment = window_end + quiz duration, as an isoformat string.
+
+    Returns None if `window_end` is falsy, or the original value (unchanged) if it cannot be
+    parsed — matching legacy, which never fabricates a time it can't derive."""
+    if not window_end:
+        return None
+    parsed = parse_quiz_end_time(window_end)
+    if parsed is None:
+        # Can't derive the visibility offset — store the value as given (legacy behaviour),
+        # but make the dropped offset visible rather than a silent early-answer hole.
+        logger.warning(
+            f"session window end {window_end!r} is unparseable; storing without the "
+            "quiz-duration offset (answer review may open at the window end, not later)"
+        )
+        return window_end
+    return (parsed + timedelta(seconds=quiz_duration_seconds(time_limit))).isoformat()

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -98,6 +98,76 @@ class TestCmsMapper(unittest.TestCase):
         self.assertEqual(quiz["max_marks"], 4)
         self.assertEqual(quiz["num_graded_questions"], 1)
 
+    def test_chapter_name_mapped_from_assembled_payload(self):
+        # The assembled problem carries chapter_name (multilingual list) + chapter_id;
+        # both must land on question metadata so chapter-level analytics can be built.
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {
+                        "text": "Q?",
+                        "options": ["A", "B", "C", "D"],
+                        "answer": ["1"],
+                        "solutions": [{"type": "text", "value": ""}],
+                    },
+                    chapter_id=34,
+                    chapter_name=[
+                        {"chapter": "मोल अवधारणा", "lang_code": "hi"},
+                        {"chapter": "Mole Concept", "lang_code": "en"},
+                    ],
+                )
+            ],
+            sections=[
+                {
+                    "type": "mcq_single_answer",
+                    "name": "",
+                    "compulsory": {
+                        "problems": [{"id": 506, "pos_marks": [4], "neg_marks": [1]}]
+                    },
+                }
+            ],
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+        meta = quiz["question_sets"][0]["questions"][0]["metadata"]
+        # picks the English name out of the multilingual list, not the first entry
+        self.assertEqual(meta["chapter"], "Mole Concept")
+        self.assertEqual(meta["chapter_id"], "34")
+
+    def test_missing_chapter_is_none(self):
+        # A problem with no chapter_name must leave chapter None (no crash) — the ETL
+        # fallback (etl-data-flow PR #116) resolves it at sync time in that case.
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {
+                        "text": "Q?",
+                        "options": ["A", "B", "C", "D"],
+                        "answer": ["1"],
+                        "solutions": [{"type": "text", "value": ""}],
+                    },
+                )
+            ],
+            sections=[
+                {
+                    "type": "mcq_single_answer",
+                    "name": "",
+                    "compulsory": {
+                        "problems": [{"id": 506, "pos_marks": [4], "neg_marks": [1]}]
+                    },
+                }
+            ],
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+        meta = quiz["question_sets"][0]["questions"][0]["metadata"]
+        self.assertIsNone(meta["chapter"])
+        self.assertIsNone(meta["chapter_id"])
+
     def test_multi_choice_partial_ladder(self):
         assembled = _test_with_problems(
             problems=[

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -1,4 +1,6 @@
+import copy
 import json
+from unittest.mock import patch
 from .base import BaseTestCase
 from ..routers import quizzes, questions
 from settings import Settings
@@ -367,7 +369,9 @@ class QuizTestCase(BaseTestCase):
         assert found.get("solution") == []
 
     def test_patch_quiz_updates_session_editable_fields(self):
-        quiz_id = self.homework_quiz_id
+        # Timed quiz (time_limit.max = 200s): the stored session_end_time is the supplied
+        # window end PLUS the quiz duration (answer-visibility time), not the raw window end.
+        quiz_id = self.timed_quiz_id
         resp = self.client.patch(
             f"{quizzes.router.prefix}/{quiz_id}",
             json={
@@ -375,7 +379,7 @@ class QuizTestCase(BaseTestCase):
                 "shuffle": True,
                 "show_scores": False,
                 "review_immediate": False,
-                "session_end_time": "2026-04-15 02:00:00 PM",
+                "session_end_time": "2026-04-15T14:00:00",
             },
         )
         assert resp.status_code == 200
@@ -394,7 +398,19 @@ class QuizTestCase(BaseTestCase):
         assert doc["shuffle"] is True
         assert doc["show_scores"] is False
         assert doc["review_immediate"] is False
-        assert doc["metadata"]["session_end_time"] == "2026-04-15 02:00:00 PM"
+        # 14:00:00 + 200s = 14:03:20
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
+
+    def test_patch_quiz_session_end_time_untimed_quiz_has_no_offset(self):
+        # An untimed quiz (time_limit None) adds no duration; the value is just normalized.
+        quiz_id = self.homework_quiz_id
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15T14:00:00"},
+        )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:00:00"
 
     def test_patch_quiz_session_end_time_when_metadata_is_null(self):
         # A quiz doc can carry metadata: null (the GET route guards for it). A dotted
@@ -406,13 +422,27 @@ class QuizTestCase(BaseTestCase):
 
         resp = self.client.patch(
             f"{quizzes.router.prefix}/{quiz_id}",
-            json={"session_end_time": "2026-04-15 02:00:00 PM"},
+            json={"session_end_time": "2026-04-15T14:00:00"},
         )
         assert resp.status_code == 200
         assert resp.json()["updated"] == ["session_end_time"]
 
         doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
-        assert doc["metadata"] == {"session_end_time": "2026-04-15 02:00:00 PM"}
+        # untimed quiz -> no offset, value normalized to isoformat
+        assert doc["metadata"] == {"session_end_time": "2026-04-15T14:00:00"}
+
+    def test_patch_quiz_session_end_time_accepts_12h_format(self):
+        # The LMS emits the legacy 12-hour "%I:%M:%S %p" format; it must parse and still get
+        # the duration offset (else the answer-review gate silently opens at the window end).
+        quiz_id = self.timed_quiz_id  # time_limit.max = 200s
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15 02:00:00 PM"},
+        )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        # 14:00:00 + 200s = 14:03:20
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
 
     def test_patch_quiz_only_touches_provided_fields(self):
         quiz_id = self.short_homework_quiz_id
@@ -438,5 +468,185 @@ class QuizTestCase(BaseTestCase):
     def test_patch_quiz_returns_404_for_unknown_id(self):
         resp = self.client.patch(
             f"{quizzes.router.prefix}/does-not-exist", json={"shuffle": True}
+        )
+        assert resp.status_code == 404
+
+    # ---- CMS from-cms create: answer-visibility time ----
+
+    def _cms_quiz_dict(self, **overrides):
+        """A quiz dict shaped like map_cms_test_to_quiz's output (1 set, 2 questions), built
+        off the homework fixture. `overrides` shallow-merge onto the top level."""
+        quiz = copy.deepcopy(self.homework_quiz_data)
+        quiz.update(overrides)
+        return quiz
+
+    def test_create_from_cms_stores_answer_visibility_time(self):
+        quiz_dict = self._cms_quiz_dict(time_limit={"min": 0, "max": 200})
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "session_end_time": "2026-04-15T14:00:00",
+                },
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        # 14:00:00 + 200s duration = 14:03:20
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
+
+    def test_create_from_cms_without_session_end_time_leaves_it_unset(self):
+        quiz_dict = self._cms_quiz_dict(time_limit={"min": 0, "max": 200})
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["metadata"].get("session_end_time") is None
+
+    # ---- regenerate in place (PUT /quiz/{id}/from-cms) ----
+
+    def test_regenerate_preserves_ids_and_refreshes_content(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        # Session-edit sets these on the quiz doc; regenerate must not reset them.
+        self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"title": "LMS Session Name", "show_scores": False},
+        )
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        old_qids = [q["_id"] for q in before["question_sets"][0]["questions"]]
+
+        # Corrected test: same structure, changed content + content-metadata.
+        new_quiz = self._cms_quiz_dict()
+        new_quiz["title"] = "CMS Test Title"  # must NOT overwrite the session name
+        new_quiz["question_sets"][0]["questions"][0]["text"] = "CORRECTED text"
+        new_quiz["metadata"]["subject"] = "Physics"  # content metadata -> refreshes
+        new_quiz["metadata"]["grade"] = "99"  # session-editable metadata -> preserved
+
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["regenerated"] is True
+
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        # quiz + question ids preserved (attempts stay linked)
+        assert after["_id"] == quiz_id
+        assert [q["_id"] for q in after["question_sets"][0]["questions"]] == old_qids
+        # question content refreshed in the questions collection
+        assert (
+            mongo_client.quiz.questions.find_one({"_id": old_qids[0]})["text"]
+            == "CORRECTED text"
+        )
+        # session-editable settings preserved
+        assert after["title"] == "LMS Session Name"
+        assert after["show_scores"] is False
+        assert after["metadata"]["grade"] == "8"  # old value kept, not the CMS "99"
+        # content metadata refreshed from the corrected test
+        assert after["metadata"]["subject"] == "Physics"
+
+    def test_regenerate_recomputes_session_end_time_with_supplied_window(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        new_quiz = self._cms_quiz_dict(time_limit={"min": 0, "max": 200})
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "session_end_time": "2026-04-15T14:00:00",
+                },
+            )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:03:20"
+
+    def test_regenerate_preserves_session_end_time_when_not_supplied(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15T14:00:00"},  # untimed -> stored as-is
+        )
+        new_quiz = self._cms_quiz_dict()
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 200
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"]["session_end_time"] == "2026-04-15T14:00:00"
+
+    def test_regenerate_refuses_structure_change(self):
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+
+        new_quiz = self._cms_quiz_dict()  # add a 3rd question -> structure differs
+        new_quiz["question_sets"][0]["questions"].append(
+            copy.deepcopy(new_quiz["question_sets"][0]["questions"][0])
+        )
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 409
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        # nothing was written
+        assert len(after["question_sets"][0]["questions"]) == len(
+            before["question_sets"][0]["questions"]
+        )
+
+    def test_regenerate_refuses_when_question_identity_changes(self):
+        # Same set/question counts, but a position is now a DIFFERENT problem (source_id
+        # changed) — a reorder or delete+add. Blindly reusing the old _id would mis-score
+        # attempts, so this must 409 with no write.
+        seed = copy.deepcopy(self.homework_quiz_data)
+        for idx, q in enumerate(seed["question_sets"][0]["questions"]):
+            q["source_id"] = f"cms-{idx}"
+        quiz_id, _ = self.post_and_get_quiz(seed)
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        old_q0_id = before["question_sets"][0]["questions"][0]["_id"]
+
+        new_quiz = copy.deepcopy(seed)
+        new_quiz["question_sets"][0]["questions"][0]["source_id"] = "cms-999"
+
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 409
+        # no write happened — the question keeps its original source_id
+        assert (
+            mongo_client.quiz.questions.find_one({"_id": old_q0_id})["source_id"]
+            == "cms-0"
+        )
+
+    def test_regenerate_returns_404_for_unknown_id(self):
+        resp = self.client.put(
+            f"{quizzes.router.prefix}/does-not-exist/from-cms",
+            json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
         )
         assert resp.status_code == 404

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -365,3 +365,78 @@ class QuizTestCase(BaseTestCase):
                 break
         assert found is not None
         assert found.get("solution") == []
+
+    def test_patch_quiz_updates_session_editable_fields(self):
+        quiz_id = self.homework_quiz_id
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={
+                "title": "Renamed by LMS",
+                "shuffle": True,
+                "show_scores": False,
+                "review_immediate": False,
+                "session_end_time": "2026-04-15 02:00:00 PM",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == quiz_id
+        assert set(body["updated"]) == {
+            "title",
+            "shuffle",
+            "show_scores",
+            "review_immediate",
+            "session_end_time",
+        }
+
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["title"] == "Renamed by LMS"
+        assert doc["shuffle"] is True
+        assert doc["show_scores"] is False
+        assert doc["review_immediate"] is False
+        assert doc["metadata"]["session_end_time"] == "2026-04-15 02:00:00 PM"
+
+    def test_patch_quiz_session_end_time_when_metadata_is_null(self):
+        # A quiz doc can carry metadata: null (the GET route guards for it). A dotted
+        # $set would raise on the null intermediate; the endpoint must handle it.
+        quiz_id = self.homework_quiz_id
+        mongo_client.quiz.quizzes.update_one(
+            {"_id": quiz_id}, {"$set": {"metadata": None}}
+        )
+
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"session_end_time": "2026-04-15 02:00:00 PM"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == ["session_end_time"]
+
+        doc = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert doc["metadata"] == {"session_end_time": "2026-04-15 02:00:00 PM"}
+
+    def test_patch_quiz_only_touches_provided_fields(self):
+        quiz_id = self.short_homework_quiz_id
+        before = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}", json={"shuffle": True}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == ["shuffle"]
+
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert after["shuffle"] is True
+        # untouched field stays as it was
+        assert after["title"] == before["title"]
+
+    def test_patch_quiz_with_no_fields_is_a_noop(self):
+        quiz_id = self.homework_quiz_id
+        resp = self.client.patch(f"{quizzes.router.prefix}/{quiz_id}", json={})
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == []
+
+    def test_patch_quiz_returns_404_for_unknown_id(self):
+        resp = self.client.patch(
+            f"{quizzes.router.prefix}/does-not-exist", json={"shuffle": True}
+        )
+        assert resp.status_code == 404

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -516,7 +516,8 @@ class QuizTestCase(BaseTestCase):
 
     def test_create_from_cms_applies_session_settings(self):
         """The PM's advanced-settings choices must land on the quiz doc: the quiz-taking
-        frontend reads shuffle/show_scores/review_immediate from there, not the session."""
+        frontend reads shuffle/show_scores/review_immediate from there, not the session.
+        """
         quiz_dict = self._cms_quiz_dict()
         # The mapper hardcodes shuffle=False and leaves the other two to the model defaults,
         # so all three differ from what's requested below.

--- a/app/tests/test_quizzes.py
+++ b/app/tests/test_quizzes.py
@@ -512,6 +512,104 @@ class QuizTestCase(BaseTestCase):
         doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
         assert doc["metadata"].get("session_end_time") is None
 
+    # ---- CMS from-cms create: session settings ----
+
+    def test_create_from_cms_applies_session_settings(self):
+        """The PM's advanced-settings choices must land on the quiz doc: the quiz-taking
+        frontend reads shuffle/show_scores/review_immediate from there, not the session."""
+        quiz_dict = self._cms_quiz_dict()
+        # The mapper hardcodes shuffle=False and leaves the other two to the model defaults,
+        # so all three differ from what's requested below.
+        quiz_dict["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "shuffle": True,
+                    "show_scores": False,
+                    "review_immediate": False,
+                },
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["shuffle"] is True
+        assert doc["show_scores"] is False
+        assert doc["review_immediate"] is False
+
+    def test_create_from_cms_without_settings_keeps_defaults(self):
+        """Omitted settings leave the mapper/model defaults alone — the field-scoped body
+        must not coerce None onto the doc."""
+        quiz_dict = self._cms_quiz_dict()
+        quiz_dict["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={"test_id": 504, "curriculum_id": 1, "grade_id": 1},
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["shuffle"] is False
+        assert doc["show_scores"] is True
+        assert doc["review_immediate"] is True
+
+    def test_create_from_cms_applies_a_single_setting_in_isolation(self):
+        """shuffle alone must not disturb the other two."""
+        quiz_dict = self._cms_quiz_dict()
+        quiz_dict["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(quiz_dict, [])
+        ):
+            resp = self.client.post(
+                f"{quizzes.router.prefix}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "shuffle": True,
+                },
+            )
+        assert resp.status_code == 201
+        doc = mongo_client.quiz.quizzes.find_one({"_id": resp.json()["id"]})
+        assert doc["shuffle"] is True
+        assert doc["show_scores"] is True
+        assert doc["review_immediate"] is True
+
+    def test_regenerate_ignores_settings_in_body_and_keeps_doc_values(self):
+        """Regenerate preserves whatever the session-edit flow last set, even if the body
+        carries settings — the create and regenerate paths share one request model."""
+        quiz_id, _ = self.post_and_get_quiz(copy.deepcopy(self.homework_quiz_data))
+        self.client.patch(
+            f"{quizzes.router.prefix}/{quiz_id}",
+            json={"shuffle": True, "show_scores": False},
+        )
+
+        new_quiz = self._cms_quiz_dict()
+        new_quiz["shuffle"] = False
+        with patch("routers.quizzes.fetch_assembled_test", return_value={}), patch(
+            "routers.quizzes.map_cms_test_to_quiz", return_value=(new_quiz, [])
+        ):
+            resp = self.client.put(
+                f"{quizzes.router.prefix}/{quiz_id}/from-cms",
+                json={
+                    "test_id": 504,
+                    "curriculum_id": 1,
+                    "grade_id": 1,
+                    "shuffle": False,
+                    "show_scores": True,
+                },
+            )
+        assert resp.status_code == 200
+        after = mongo_client.quiz.quizzes.find_one({"_id": quiz_id})
+        assert after["shuffle"] is True
+        assert after["show_scores"] is False
+
     # ---- regenerate in place (PUT /quiz/{id}/from-cms) ----
 
     def test_regenerate_preserves_ids_and_refreshes_content(self):

--- a/release-notes/gather.sh
+++ b/release-notes/gather.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Gather last week's merged work into a digest for the release-notes LLM.
+#
+# Walks: merged PRs -> closingIssuesReferences -> native sub-issue parent
+# (the PRD issue), deduping parents. PRs with no linked issues contribute
+# their body alone. Falls back to raw commits when no PRs merged; skips
+# the release entirely when there are neither.
+#
+# Env:   GITHUB_TOKEN (required), GH_REPO (owner/repo), WINDOW_DAYS (default 7),
+#        DEFAULT_BRANCH (default main), OUT_DIR (default out)
+# Writes: $OUT_DIR/context.md
+# Outputs (GITHUB_OUTPUT): skip=true|false, mode=prs|commits, tag=vYYYY.MM.DD
+
+set -euo pipefail
+
+REPO="${GH_REPO:?GH_REPO required (owner/repo)}"
+WINDOW_DAYS="${WINDOW_DAYS:-7}"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+OUT_DIR="${OUT_DIR:-out}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+PR_BODY_LIMIT=2000
+PARENT_BODY_LIMIT=3000
+
+mkdir -p "$OUT_DIR"
+CONTEXT="$OUT_DIR/context.md"
+
+# GNU date (CI) with BSD/macOS fallback for local runs outside a container.
+SINCE_DATE=$(date -u -d "-${WINDOW_DAYS} days" +%Y-%m-%d 2>/dev/null || date -u -v-"${WINDOW_DAYS}"d +%Y-%m-%d)
+SINCE_ISO="${SINCE_DATE}T00:00:00Z"
+TAG="v$(date -u +%Y.%m.%d)"
+
+# Human-readable window label for release/post titles, e.g. "Jul 4 – Jul 18, 2026"
+fmt_day() { { date -u -d "$1" "+%b %d" 2>/dev/null || date -ju -f %Y-%m-%d "$1" "+%b %d"; } | sed 's/ 0/ /'; }
+RANGE="$(fmt_day "$SINCE_DATE") – $(date -u "+%b %d, %Y" | sed 's/ 0/ /')"
+
+echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+echo "range=$RANGE" >> "$GITHUB_OUTPUT"
+
+prs=$(gh pr list --repo "$REPO" --state merged \
+  --search "merged:>=$SINCE_DATE base:$DEFAULT_BRANCH" \
+  --json number,title,url,body,mergedAt,author --limit 100)
+
+pr_count=$(jq 'length' <<<"$prs")
+
+if [ "$pr_count" -gt 0 ]; then
+  echo "Found $pr_count merged PRs since $SINCE_DATE" >&2
+
+  # Deterministic changelog appended verbatim after the LLM's narrative notes.
+  {
+    echo "## 📋 Changelog"
+    echo
+    jq -r 'sort_by(.mergedAt) | reverse | .[] |
+      "- [#\(.number)](\(.url)) \(.title) — @\(.author.login)"' <<<"$prs"
+  } > "$OUT_DIR/changelog.md"
+
+  {
+    echo "# Work merged into $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
+    echo
+    echo "## Merged pull requests"
+  } > "$CONTEXT"
+
+  owner="${REPO%/*}"; name="${REPO#*/}"
+  parents="$OUT_DIR/parents.jsonl"; : > "$parents"
+
+  for pr in $(jq -r '.[].number' <<<"$prs"); do
+    jq -r --argjson n "$pr" --argjson limit "$PR_BODY_LIMIT" '
+      .[] | select(.number == $n) |
+      "\n### PR #\(.number): \(.title)\nAuthor: @\(.author.login) · Merged: \(.mergedAt) · \(.url)\n\n\(.body // "" | .[0:$limit])\n"
+    ' <<<"$prs" >> "$CONTEXT"
+
+    linked=$(gh api graphql \
+      -f query='query($owner:String!,$name:String!,$pr:Int!){
+        repository(owner:$owner,name:$name){
+          pullRequest(number:$pr){
+            closingIssuesReferences(first:10){
+              nodes{ number title parent{ number title body } }
+            }}}}' \
+      -f owner="$owner" -f name="$name" -F pr="$pr" \
+      --jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
+
+    if [ "$(jq 'length' <<<"$linked")" -gt 0 ]; then
+      echo "Closes issues:" >> "$CONTEXT"
+      jq -r '.[] | "- #\(.number) \(.title)\(if .parent then " (part of initiative #\(.parent.number): \(.parent.title))" else "" end)"' \
+        <<<"$linked" >> "$CONTEXT"
+      jq -c '.[] | select(.parent) | .parent' <<<"$linked" >> "$parents"
+    fi
+  done
+
+  if [ -s "$parents" ]; then
+    {
+      echo
+      echo "## Parent initiatives (the why behind the PRs)"
+    } >> "$CONTEXT"
+    jq -rs --argjson limit "$PARENT_BODY_LIMIT" '
+      unique_by(.number) | .[] |
+      "\n### Initiative #\(.number): \(.title)\n\n\(.body // "" | .[0:$limit])\n"
+    ' "$parents" >> "$CONTEXT"
+  fi
+
+  echo "mode=prs" >> "$GITHUB_OUTPUT"
+  echo "skip=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "No merged PRs since $SINCE_DATE; checking commits on $DEFAULT_BRANCH" >&2
+commits=$(gh api "repos/$REPO/commits?since=$SINCE_ISO&sha=$DEFAULT_BRANCH&per_page=100" \
+  --jq '[.[] | select(.commit.message | startswith("Merge pull request") | not)]')
+
+commit_count=$(jq 'length' <<<"$commits")
+
+if [ "$commit_count" -eq 0 ]; then
+  echo "Quiet week: no PRs, no commits. Skipping release." >&2
+  echo "mode=none" >> "$GITHUB_OUTPUT"
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "Found $commit_count commits since $SINCE_DATE" >&2
+{
+  echo "## 📋 Changelog"
+  echo
+  jq -r '.[] | "- [`\(.sha[0:7])`](\(.html_url)) \(.commit.message | split("\n")[0]) — @\(.author.login // .commit.author.name)"' <<<"$commits"
+} > "$OUT_DIR/changelog.md"
+{
+  echo "# Work committed to $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
+  echo
+  echo "No pull requests were merged this week; these are direct commits."
+  echo
+  jq -r '.[] | "- \(.commit.message | split("\n")[0]) — @\(.author.login // .commit.author.name) (\(.html_url))"' <<<"$commits"
+} > "$CONTEXT"
+
+echo "mode=commits" >> "$GITHUB_OUTPUT"
+echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/release-notes/system-prompt.md
+++ b/release-notes/system-prompt.md
@@ -1,0 +1,19 @@
+You are the release-notes writer for Avanti Fellows engineering. You receive a digest of the pull requests merged into a repository during the release window (typically the last two weeks) — sometimes with the parent initiative issues ("the why behind the PRs"), sometimes a plain commit list. Write the release notes for that window.
+
+Audience: the whole organisation — program staff who never read code AND engineers. Lead for the non-technical reader; keep technical substance present but secondary.
+
+Output exactly this structure, in markdown, and nothing else (no preamble, no sign-off):
+
+1. The opener: a line containing only `**TL;DR**`, then 2 to 4 bullets. Each bullet is one short, plain sentence (about 15 words or fewer) naming one change and who it helps. No jargon, no PR numbers, no issue numbers. `**TL;DR**` is bold text, not a heading — the output's first character must never be `#`.
+2. `## ✨ New` — user-visible features and capabilities.
+3. `## 🐛 Fixes` — bugs fixed, phrased by user impact.
+4. `## 🔧 Maintenance` — refactors, CI, tooling, docs.
+
+Bullet rules:
+- One bullet per PR; merge trivially-related PRs into one bullet.
+- Phrase by outcome ("Program Admins can now manage their own visits"), never by implementation ("refactored visits-policy module").
+- When a parent initiative is given, use it to explain the why in the bullet.
+- End every bullet with the PR link and credit: `([#208](url)) — thanks @author`.
+- For a commit-only window, bullets cite commits instead of PRs and the TL;DR says the work landed as direct commits.
+
+Write simply, everywhere: short sentences, everyday words, one idea per bullet, no parenthetical detail-stacking. Readers skim this — a detailed changelog is appended after your output, so you never need to be exhaustive. Omit any section that has no items. Keep the whole output under 250 words. Never invent work that is not in the digest.


### PR DESCRIPTION
Promotes `main` → `release` (prod deploy) to ship the CMS quiz-session backend work.

## What ships

**[#161](https://github.com/avantifellows/quiz-backend/pull/161) — CMS quiz-session settings, patch and regenerate**

- `PATCH /quiz/{quiz_id}` — field-scoped patch of the session-editable settings on an existing quiz, in place (same `_id`): `title`, `shuffle`, `show_scores`, `review_immediate`, `metadata.session_end_time`.
- `PUT /quiz/{quiz_id}/from-cms` — regenerate in place: re-ingests a corrected CMS test into the **same** quiz/set/question `_id`s so the session and submitted attempts stay linked. Refuses with **409** on a structure change rather than remapping answer keys onto the wrong questions.
- `POST /quiz/from-cms` now accepts `shuffle` / `show_scores` / `review_immediate` and applies them over the mapper defaults. This is the fix for the reported bug where a PM's advanced-settings choices were silently ignored on new CMS chapter tests — the mapper hardcodes `shuffle: False` and the model defaults the other two to `True`, and the quiz player reads all three off the quiz doc.
- `services/quiz_time.py` — answer-visibility time = window end **+ quiz duration** (`time_limit.max`), ported verbatim from the legacy sessionCreator's `_quiz_answer_visibility_end_time`. Also fixes a Phase-1 gap where the CMS create path never set `session_end_time` at all, so `review_immediate=false` could not defer review.

Plus release tooling and CMS ingest fixes already on `main` (#163 comprehension→numerical mapping, #164 question chapter metadata, #166/#167/#168 biweekly release runner).

## Safety

- All new request fields are `Optional[... ] = None` and applied only when explicitly supplied, so existing callers — everything in prod today — are unaffected.
- The new endpoints are additive; nothing invokes them until the af_lms side ships.
- Regenerate preserves the session-editable settings across a re-ingest, with a test that passes contradicting body values and asserts the stored doc wins.

## Verification

- **96 tests pass** on the merged `main`→`release` tree (run locally against the exact prospective tree, not just on `main`).
- Merge is clean, no conflicts. Confirmed the duplicate `#164` cherry-pick on `release` did not clobber the chapter-metadata change, and the mapper's `shuffle: False` default my change overrides is still in place after 17 commits of drift.
- CI green on #161 (Pre-commit, Test cases).

## Follow-up — not in this PR

- **af_lms [#242](https://github.com/avantifellows/af_lms/pull/242) must follow.** This deploy alone fixes nothing user-visible; the PM-facing shuffle bug only clears once the LMS sends the settings. Order matters: quiz-backend first, or LMS creates fail *silently* by falling back to defaults.
- **Regenerate is not transactional** — question docs are written before the quiz doc, so a mid-loop infra failure could leave refreshed questions against a stale embedded grading subset. The alignment guard validates fully *before* any write, so partial state requires an infra failure. Tracked for a replica-set transaction.
- **No re-scoring on regenerate.** Existing attempts keep their original scores against the old answer key; quiz-backend has no rescore path.
