### PR TITLE
fix(cms-ingest): read problem content from lang_versions

### DIFF
--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -14,7 +14,10 @@ Contract (locked with the CMS owner — see task lms-cms-tests):
 - Assembled shape: {"test": Test, "problems": [Problem, ...]}. `test.type_params` carries
   the structure (subjects -> sections -> compulsory/optional problem refs) and marks at
   four levels (test / subject / section / problem). `problems` is a flat list of
-  fully-resolved problems (text, options, answer, paragraph) joined to their refs by id.
+  fully-resolved problems joined to their refs by id. Since the CMS added multilingual
+  problems, each problem's content (text, options, answer, solutions) lives per language
+  in `lang_versions[{lang_code, meta_data}]`; the top-level `meta_data` is retained but
+  empty. We ingest the English version — see `_problem_meta`.
 - Choice answers are 1-based option numbers; the quiz engine wants 0-based indices.
   Numerical and comprehension answers are numeric values.
 - Marks cascade problem-ref -> section -> subject -> test; the lowest level that sets
@@ -66,6 +69,11 @@ CHOICE_TYPE_MAP = {
     "matrix_match": "single-choice",  # single-answer; table baked into the question HTML
 }
 NUMERIC_SUBTYPES = ("numerical_answer", "integer_type", "comprehension")
+
+# Language whose content we ingest. The CMS authors every problem in English (mandatory)
+# and regional languages are optional additions, so English is the only complete version
+# and the quiz engine has no per-language question storage to put the others in.
+CMS_PRIMARY_LANG = "en"
 
 # Instruction blurbs shown at the top of a question set, keyed on the set's question type
 # (ported from QuizInterface.QUESTION_SET_TYPE_INSTRUCTION_MAPPING).
@@ -169,6 +177,24 @@ def _chapter_name(problem: Dict[str, Any]) -> Optional[str]:
     return (entries[0].get("chapter") or None) if entries else None
 
 
+def _problem_meta(problem: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve a problem's content (text / options / answer / solutions).
+
+    Since nex-gen-cms PR #170 (multilingual problems) the content lives per language in
+    `lang_versions[]`, and the flat top-level `meta_data` is still present but empty
+    ({"text": "", "options": null, "answer": null}). Reading the flat copy therefore
+    yields a structurally valid quiz whose questions are all blank — which is exactly
+    what shipped to students before this was caught, so prefer the English lang version
+    and fall back to the flat copy only for pre-#170 payloads.
+    """
+    for version in problem.get("lang_versions") or []:
+        if version.get("lang_code") == CMS_PRIMARY_LANG:
+            meta = version.get("meta_data")
+            if meta:
+                return meta
+    return problem.get("meta_data") or {}
+
+
 def _problem_metadata(problem: Dict[str, Any], subject_name: str) -> Dict[str, Any]:
     return {
         # subject_name is the plain, resolved subject name from the test structure;
@@ -196,7 +222,7 @@ def _map_problem(
     base marking_scheme (correct/wrong from the marks cascade; no partial — that is set at
     the set level once the set's type is known). Returns (question, warnings)."""
     warnings: List[str] = []
-    meta = problem.get("meta_data") or {}
+    meta = _problem_meta(problem)
     subtype = problem.get("subtype") or ""
     answers = meta.get("answer") or []
     problem_id = problem.get("id")

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -674,5 +674,168 @@ class TestCmsMapper(unittest.TestCase):
         self.assertIn("+4.0", description)
 
 
+class TestMultilingualContent(unittest.TestCase):
+    """Since nex-gen-cms added multilingual problems, content lives per language in
+    `lang_versions[]` and the flat top-level `meta_data` is present but empty. Reading
+    the flat copy produces a structurally valid quiz with every question blank, which
+    reached students before it was caught — so pin the resolution order here.
+    """
+
+    @staticmethod
+    def _single_choice_section():
+        return [
+            {
+                "type": "mcq_single_answer",
+                "name": "",
+                "compulsory": {
+                    "problems": [{"id": 506, "pos_marks": [4], "neg_marks": [1]}]
+                },
+            }
+        ]
+
+    def test_reads_english_lang_version_when_flat_meta_data_is_empty(self):
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "", "options": None, "answer": None, "solutions": None},
+                    lang_versions=[
+                        {
+                            "lang_code": "en",
+                            "meta_data": {
+                                "text": "Avanti?",
+                                "options": ["A", "B", "C", "D"],
+                                "answer": ["2"],
+                                "solutions": [{"type": "text", "value": "because"}],
+                            },
+                        }
+                    ],
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, warnings = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Avanti?")
+        self.assertEqual([o["text"] for o in question["options"]], ["A", "B", "C", "D"])
+        self.assertEqual(question["correct_answer"], [1])
+        self.assertTrue(question["graded"])
+        self.assertEqual(question["solution"], ["because"])
+        self.assertEqual(warnings, [])
+
+    def test_prefers_english_over_regional_languages(self):
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "", "options": None, "answer": None},
+                    lang_versions=[
+                        {
+                            "lang_code": "hi",
+                            "meta_data": {
+                                "text": "हिंदी",
+                                "options": ["क", "ख", "ग", "घ"],
+                                "answer": ["4"],
+                            },
+                        },
+                        {
+                            "lang_code": "en",
+                            "meta_data": {
+                                "text": "Avanti?",
+                                "options": ["A", "B", "C", "D"],
+                                "answer": ["2"],
+                            },
+                        },
+                    ],
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Avanti?")
+        self.assertEqual(question["correct_answer"], [1])
+
+    def test_falls_back_to_flat_meta_data_for_pre_multilingual_payloads(self):
+        """Older payloads carry no lang_versions at all — keep ingesting them."""
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "Legacy?", "options": ["A", "B"], "answer": ["1"]},
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Legacy?")
+        self.assertEqual(question["correct_answer"], [0])
+
+    def test_falls_back_when_english_lang_version_is_empty(self):
+        """An empty `en` meta_data must not shadow a populated flat copy."""
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "Flat?", "options": ["A", "B"], "answer": ["2"]},
+                    lang_versions=[{"lang_code": "en", "meta_data": {}}],
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Flat?")
+        self.assertEqual(question["correct_answer"], [1])
+
+    def test_numerical_answer_comes_from_lang_version(self):
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    777,
+                    "integer_type",
+                    {"text": "", "answer": None},
+                    lang_versions=[
+                        {
+                            "lang_code": "en",
+                            "meta_data": {"text": "Unpaired electrons?", "answer": ["3"]},
+                        }
+                    ],
+                )
+            ],
+            sections=[
+                {
+                    "type": "integer_type",
+                    "name": "",
+                    "compulsory": {
+                        "problems": [{"id": 777, "pos_marks": [4], "neg_marks": [1]}]
+                    },
+                }
+            ],
+        )
+
+        quiz, warnings = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["type"], "numerical-integer")
+        self.assertEqual(question["text"], "Unpaired electrons?")
+        self.assertEqual(question["correct_answer"], 3)
+        self.assertTrue(question["graded"])
+        self.assertEqual(warnings, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -811,7 +811,10 @@ class TestMultilingualContent(unittest.TestCase):
                     lang_versions=[
                         {
                             "lang_code": "en",
-                            "meta_data": {"text": "Unpaired electrons?", "answer": ["3"]},
+                            "meta_data": {
+                                "text": "Unpaired electrons?",
+                                "answer": ["3"],
+                            },
                         }
                     ],
                 )


### PR DESCRIPTION
## The bug

Every CMS-sourced quiz is being created with **all questions blank** — no text, no options, no answer, `graded: false`. Students opening the session see nothing.

Reported case: session `EnableStudents_6a69eec2b02e39c96e4e9484` (chapter test 1869, "12C23 - The d and f-Block Elements - Main", 25 questions), created 2026-07-29 17:44 IST with a 17:44–21:44 IST window.

## Cause

nex-gen-cms [PR #170](https://github.com/avantifellows/nex-gen-cms/pull/170) (multilingual problem support) moved problem content into a per-language `lang_versions[]` array. It shipped to prod via nex-gen-cms #173 at **2026-07-29 16:11 IST** — 93 minutes before this session was created.

Crucially, #170 *added* `LangVersions` alongside the existing `MetaData` field rather than replacing it, so the flat `meta_data` is still present in the assembled-test JSON — just empty:

```
problem 1828:
  meta_data        → {text: "", options: null, answer: null}        ← what this mapper read
  lang_versions[0] → {lang_code: "en", meta_data: {text: "The 'spin-only' magnetic
                      moment ... of Ni(2+) would be:", options: [4], answer: ["1"], ...}}
```

`lang_versions` appeared nowhere in `cms_ingest.py`, so the mapper read the empty envelope and faithfully built 25 well-formed empty questions.

## Why nothing caught it

- The quiz **header** stays correct — `max_marks: 100`, `num_graded_questions: 25`, right section titles ("Chemistry - MCQ Single Answer"), right counts (20 MCQ + 5 integer). Only the bodies are blank.
- The create path succeeded, so the session's `meta_data.status` is `"success"` and it looks healthy in the LMS.
- The `problem referenced by test but not resolved` guard never fires — the problems *do* resolve, they're just empty.
- The per-question `no answer -> ungraded` warnings did fire 25 times, but af_lms returns quiz-build warnings as a non-fatal notice appended to a **success** toast.

A removed field would have thrown; an emptied one produces a valid, empty quiz.

## Fix

Resolve content from the English lang version, falling back to the flat copy so pre-#170 payloads keep working. English is the right choice: the CMS makes it mandatory and treats regional languages as optional additions, and the quiz engine has no per-language question storage to put the others in.

## Verification

Ran the patched mapper against the **live** assembled payload for test 1869:

| | before | after |
|---|---|---|
| questions | 25 | 25 |
| blank text | 25 | **0** |
| missing options | 25 | **0** |
| missing answer | 25 | **0** |
| ungraded | 25 | **0** |
| warnings | 25 | **0** |
| max_marks | 100 | 100 |

Answer mapping spot-checked: CMS `answer: ["1"]` → `correct_answer: [0]` (1-based → 0-based); Ni²⁺ spin-only moment is 2.82 BM = option index 0. Marking cascades to +4/−1.

Scope check: 6 other chapter tests sampled (1060, 1196, 1205, 1229, 1232, 1326) — all 25/25 problems have content in `lang_versions` and 0/25 flat. This is the CMS-wide steady state now, so **every** quiz created via `/quiz/from-cms` since 16:11 IST Jul 29 is affected.

## Tests

23 pass. 5 added covering the multilingual shape; **3 of them fail without the one-line fix** (the 2 fallback tests pass both ways by design — they guard the pre-#170 path).

## Deploy note

This must ship before affected sessions are repaired: regenerate (`PUT /quiz/{id}/from-cms`) runs this mapper, so re-ingesting on current prod would rewrite the same blanks. Once deployed, regenerate is in-place and keeps quiz IDs and student links valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)