### PR TITLE
Prod release: fix blank questions in CMS-sourced quizzes

### DIFF
--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -14,7 +14,10 @@ Contract (locked with the CMS owner — see task lms-cms-tests):
 - Assembled shape: {"test": Test, "problems": [Problem, ...]}. `test.type_params` carries
   the structure (subjects -> sections -> compulsory/optional problem refs) and marks at
   four levels (test / subject / section / problem). `problems` is a flat list of
-  fully-resolved problems (text, options, answer, paragraph) joined to their refs by id.
+  fully-resolved problems joined to their refs by id. Since the CMS added multilingual
+  problems, each problem's content (text, options, answer, solutions) lives per language
+  in `lang_versions[{lang_code, meta_data}]`; the top-level `meta_data` is retained but
+  empty. We ingest the English version — see `_problem_meta`.
 - Choice answers are 1-based option numbers; the quiz engine wants 0-based indices.
   Numerical and comprehension answers are numeric values.
 - Marks cascade problem-ref -> section -> subject -> test; the lowest level that sets
@@ -66,6 +69,11 @@ CHOICE_TYPE_MAP = {
     "matrix_match": "single-choice",  # single-answer; table baked into the question HTML
 }
 NUMERIC_SUBTYPES = ("numerical_answer", "integer_type", "comprehension")
+
+# Language whose content we ingest. The CMS authors every problem in English (mandatory)
+# and regional languages are optional additions, so English is the only complete version
+# and the quiz engine has no per-language question storage to put the others in.
+CMS_PRIMARY_LANG = "en"
 
 # Instruction blurbs shown at the top of a question set, keyed on the set's question type
 # (ported from QuizInterface.QUESTION_SET_TYPE_INSTRUCTION_MAPPING).
@@ -169,6 +177,24 @@ def _chapter_name(problem: Dict[str, Any]) -> Optional[str]:
     return (entries[0].get("chapter") or None) if entries else None
 
 
+def _problem_meta(problem: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve a problem's content (text / options / answer / solutions).
+
+    Since nex-gen-cms PR #170 (multilingual problems) the content lives per language in
+    `lang_versions[]`, and the flat top-level `meta_data` is still present but empty
+    ({"text": "", "options": null, "answer": null}). Reading the flat copy therefore
+    yields a structurally valid quiz whose questions are all blank — which is exactly
+    what shipped to students before this was caught, so prefer the English lang version
+    and fall back to the flat copy only for pre-#170 payloads.
+    """
+    for version in problem.get("lang_versions") or []:
+        if version.get("lang_code") == CMS_PRIMARY_LANG:
+            meta = version.get("meta_data")
+            if meta:
+                return meta
+    return problem.get("meta_data") or {}
+
+
 def _problem_metadata(problem: Dict[str, Any], subject_name: str) -> Dict[str, Any]:
     return {
         # subject_name is the plain, resolved subject name from the test structure;
@@ -196,7 +222,7 @@ def _map_problem(
     base marking_scheme (correct/wrong from the marks cascade; no partial — that is set at
     the set level once the set's type is known). Returns (question, warnings)."""
     warnings: List[str] = []
-    meta = problem.get("meta_data") or {}
+    meta = _problem_meta(problem)
     subtype = problem.get("subtype") or ""
     answers = meta.get("answer") or []
     problem_id = problem.get("id")

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -674,5 +674,168 @@ class TestCmsMapper(unittest.TestCase):
         self.assertIn("+4.0", description)
 
 
+class TestMultilingualContent(unittest.TestCase):
+    """Since nex-gen-cms added multilingual problems, content lives per language in
+    `lang_versions[]` and the flat top-level `meta_data` is present but empty. Reading
+    the flat copy produces a structurally valid quiz with every question blank, which
+    reached students before it was caught — so pin the resolution order here.
+    """
+
+    @staticmethod
+    def _single_choice_section():
+        return [
+            {
+                "type": "mcq_single_answer",
+                "name": "",
+                "compulsory": {
+                    "problems": [{"id": 506, "pos_marks": [4], "neg_marks": [1]}]
+                },
+            }
+        ]
+
+    def test_reads_english_lang_version_when_flat_meta_data_is_empty(self):
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "", "options": None, "answer": None, "solutions": None},
+                    lang_versions=[
+                        {
+                            "lang_code": "en",
+                            "meta_data": {
+                                "text": "Avanti?",
+                                "options": ["A", "B", "C", "D"],
+                                "answer": ["2"],
+                                "solutions": [{"type": "text", "value": "because"}],
+                            },
+                        }
+                    ],
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, warnings = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Avanti?")
+        self.assertEqual([o["text"] for o in question["options"]], ["A", "B", "C", "D"])
+        self.assertEqual(question["correct_answer"], [1])
+        self.assertTrue(question["graded"])
+        self.assertEqual(question["solution"], ["because"])
+        self.assertEqual(warnings, [])
+
+    def test_prefers_english_over_regional_languages(self):
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "", "options": None, "answer": None},
+                    lang_versions=[
+                        {
+                            "lang_code": "hi",
+                            "meta_data": {
+                                "text": "हिंदी",
+                                "options": ["क", "ख", "ग", "घ"],
+                                "answer": ["4"],
+                            },
+                        },
+                        {
+                            "lang_code": "en",
+                            "meta_data": {
+                                "text": "Avanti?",
+                                "options": ["A", "B", "C", "D"],
+                                "answer": ["2"],
+                            },
+                        },
+                    ],
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Avanti?")
+        self.assertEqual(question["correct_answer"], [1])
+
+    def test_falls_back_to_flat_meta_data_for_pre_multilingual_payloads(self):
+        """Older payloads carry no lang_versions at all — keep ingesting them."""
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "Legacy?", "options": ["A", "B"], "answer": ["1"]},
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Legacy?")
+        self.assertEqual(question["correct_answer"], [0])
+
+    def test_falls_back_when_english_lang_version_is_empty(self):
+        """An empty `en` meta_data must not shadow a populated flat copy."""
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    506,
+                    "mcq_single_answer",
+                    {"text": "Flat?", "options": ["A", "B"], "answer": ["2"]},
+                    lang_versions=[{"lang_code": "en", "meta_data": {}}],
+                )
+            ],
+            sections=self._single_choice_section(),
+        )
+
+        quiz, _ = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["text"], "Flat?")
+        self.assertEqual(question["correct_answer"], [1])
+
+    def test_numerical_answer_comes_from_lang_version(self):
+        assembled = _test_with_problems(
+            problems=[
+                _problem(
+                    777,
+                    "integer_type",
+                    {"text": "", "answer": None},
+                    lang_versions=[
+                        {
+                            "lang_code": "en",
+                            "meta_data": {"text": "Unpaired electrons?", "answer": ["3"]},
+                        }
+                    ],
+                )
+            ],
+            sections=[
+                {
+                    "type": "integer_type",
+                    "name": "",
+                    "compulsory": {
+                        "problems": [{"id": 777, "pos_marks": [4], "neg_marks": [1]}]
+                    },
+                }
+            ],
+        )
+
+        quiz, warnings = map_cms_test_to_quiz(assembled)
+
+        question = quiz["question_sets"][0]["questions"][0]
+        self.assertEqual(question["type"], "numerical-integer")
+        self.assertEqual(question["text"], "Unpaired electrons?")
+        self.assertEqual(question["correct_answer"], 3)
+        self.assertTrue(question["graded"])
+        self.assertEqual(warnings, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -811,7 +811,10 @@ class TestMultilingualContent(unittest.TestCase):
                     lang_versions=[
                         {
                             "lang_code": "en",
-                            "meta_data": {"text": "Unpaired electrons?", "answer": ["3"]},
+                            "meta_data": {
+                                "text": "Unpaired electrons?",
+                                "answer": ["3"],
+                            },
                         }
                     ],
                 )


### PR DESCRIPTION
Promotes #171 to prod.

## Why this is urgent

Every CMS-sourced quiz created since **2026-07-29 16:11 IST** has all questions blank — no text, no options, no answer. Students opening the session see nothing.

Reported case: `EnableStudents_6a69eec2b02e39c96e4e9484` (chapter test 1869, 25 questions), created 17:44 IST.

## Cause

nex-gen-cms [#170](https://github.com/avantifellows/nex-gen-cms/pull/170) moved problem content into a per-language `lang_versions[]` array, shipping to prod at 16:11 IST. It added the field alongside the flat `meta_data` instead of replacing it, so `meta_data` still parsed — just empty. The mapper read the empty copy and built well-formed empty questions, which is why the quiz header (`max_marks`, question counts, section titles) stayed correct and nothing alerted.

## Contents

Only #171 — `app/services/cms_ingest.py` (+30) and its tests (+166). No other commits ride along.

## Verified

Patched mapper run against the live assembled payload for test 1869: 25/25 questions now carry text, options and answers; blank/missing-options/missing-answer/ungraded/warnings all 0 (were 25 each); `max_marks` unchanged at 100. 23 tests pass; 3 of the 5 added fail without the fix.

## After deploy

Affected sessions need re-ingesting via `PUT /quiz/{id}/from-cms`. That runs this mapper, so it must not be attempted until this is live. Regenerate is in-place — quiz IDs and student links stay valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)