### PR TITLE
fix(cms-ingest): make curriculum_id/grade_id optional on /quiz/from-cms

### DIFF
--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -192,13 +192,8 @@ class CmsQuizIngestRequest(BaseModel):
     """
 
     test_id: int
-    # Optional: the CMS assembled-test endpoint ignores their VALUES — a test is identified
-    # by `id` alone and `/api/service/test` returns the same problems whichever
-    # curriculum/grade is passed (a test can be tagged to several curriculum-grade pairs).
-    # They are still sent downstream because that endpoint 502s when they are absent, so
-    # fetch_assembled_test substitutes a placeholder. Callers that know the real pair should
-    # keep passing it; callers holding only a test link — nex-gen-cms shortened its test URLs
-    # to `/test?id=<id>` — can now omit them.
+    # Optional: the CMS identifies a test by `id` alone and ignores these values. Callers
+    # holding only a shortened CMS link (`/test?id=<id>`) can omit them.
     curriculum_id: Optional[int] = None
     grade_id: Optional[int] = None
     quiz_type: str = QuizType.assessment.value

--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -192,8 +192,15 @@ class CmsQuizIngestRequest(BaseModel):
     """
 
     test_id: int
-    curriculum_id: int
-    grade_id: int
+    # Optional: the CMS assembled-test endpoint ignores their VALUES — a test is identified
+    # by `id` alone and `/api/service/test` returns the same problems whichever
+    # curriculum/grade is passed (a test can be tagged to several curriculum-grade pairs).
+    # They are still sent downstream because that endpoint 502s when they are absent, so
+    # fetch_assembled_test substitutes a placeholder. Callers that know the real pair should
+    # keep passing it; callers holding only a test link — nex-gen-cms shortened its test URLs
+    # to `/test?id=<id>` — can now omit them.
+    curriculum_id: Optional[int] = None
+    grade_id: Optional[int] = None
     quiz_type: str = QuizType.assessment.value
     # Raw session window-end as an ISO wall-clock string (IST), e.g. "2026-04-15T14:00:00".
     # The stored metadata.session_end_time is this PLUS the quiz duration (see

--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -91,6 +91,8 @@ class CmsIngestError(Exception):
 
 # The CMS ignores these values but 502s if curriculum_id is missing, so send a placeholder
 # when the caller doesn't know the pair.
+# TEMPORARY: delete once db-service #651 ships (PR #677) — it drops the redundant
+# curriculum_id filter that makes an empty param blow up.
 _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID = 1
 
 

--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -89,13 +89,6 @@ class CmsIngestError(Exception):
     """Raised when the CMS assembled-test JSON cannot be fetched or is unusable."""
 
 
-# The CMS ignores these values but 502s if curriculum_id is missing, so send a placeholder
-# when the caller doesn't know the pair.
-# TEMPORARY: delete once db-service #651 ships (PR #677) — it drops the redundant
-# curriculum_id filter that makes an empty param blow up.
-_CMS_PLACEHOLDER_CURRICULUM_GRADE_ID = 1
-
-
 def fetch_assembled_test(
     test_id: int,
     curriculum_id: Optional[int] = None,
@@ -103,30 +96,25 @@ def fetch_assembled_test(
 ) -> Dict[str, Any]:
     """Fetch the assembled-test JSON from the new CMS. Raises CmsIngestError on failure.
 
-    curriculum_id/grade_id are optional; see _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID.
+    A test is identified by its id alone; curriculum_id/grade_id are optional and only
+    forwarded when the caller knows them.
     """
     if not settings.cms_service_endpoint or not settings.cms_service_token:
         raise CmsIngestError(
             "CMS_SERVICE_ENDPOINT / CMS_SERVICE_TOKEN are not configured"
         )
 
+    params = {"id": test_id}
+    if curriculum_id is not None:
+        params["curriculum_id"] = curriculum_id
+    if grade_id is not None:
+        params["grade_id"] = grade_id
+
     url = settings.cms_service_endpoint.rstrip("/") + "/api/service/test"
     try:
         response = requests.get(
             url,
-            params={
-                "id": test_id,
-                "curriculum_id": (
-                    curriculum_id
-                    if curriculum_id is not None
-                    else _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
-                ),
-                "grade_id": (
-                    grade_id
-                    if grade_id is not None
-                    else _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
-                ),
-            },
+            params=params,
             headers={"Authorization": f"Bearer {settings.cms_service_token}"},
             timeout=30,
         )

--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -89,10 +89,8 @@ class CmsIngestError(Exception):
     """Raised when the CMS assembled-test JSON cannot be fetched or is unusable."""
 
 
-# The CMS assembled-test endpoint requires curriculum_id/grade_id to be PRESENT (it 502s
-# without them) but ignores their values: `/api/service/test?id=X` returns the same problems
-# for any pair, and a test may be tagged to several pairs. So when a caller doesn't know the
-# pair, send a placeholder rather than refuse the ingest.
+# The CMS ignores these values but 502s if curriculum_id is missing, so send a placeholder
+# when the caller doesn't know the pair.
 _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID = 1
 
 

--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -89,10 +89,22 @@ class CmsIngestError(Exception):
     """Raised when the CMS assembled-test JSON cannot be fetched or is unusable."""
 
 
+# The CMS assembled-test endpoint requires curriculum_id/grade_id to be PRESENT (it 502s
+# without them) but ignores their values: `/api/service/test?id=X` returns the same problems
+# for any pair, and a test may be tagged to several pairs. So when a caller doesn't know the
+# pair, send a placeholder rather than refuse the ingest.
+_CMS_PLACEHOLDER_CURRICULUM_GRADE_ID = 1
+
+
 def fetch_assembled_test(
-    test_id: int, curriculum_id: int, grade_id: int
+    test_id: int,
+    curriculum_id: Optional[int] = None,
+    grade_id: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Fetch the assembled-test JSON from the new CMS. Raises CmsIngestError on failure."""
+    """Fetch the assembled-test JSON from the new CMS. Raises CmsIngestError on failure.
+
+    curriculum_id/grade_id are optional; see _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID.
+    """
     if not settings.cms_service_endpoint or not settings.cms_service_token:
         raise CmsIngestError(
             "CMS_SERVICE_ENDPOINT / CMS_SERVICE_TOKEN are not configured"
@@ -104,8 +116,16 @@ def fetch_assembled_test(
             url,
             params={
                 "id": test_id,
-                "curriculum_id": curriculum_id,
-                "grade_id": grade_id,
+                "curriculum_id": (
+                    curriculum_id
+                    if curriculum_id is not None
+                    else _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
+                ),
+                "grade_id": (
+                    grade_id
+                    if grade_id is not None
+                    else _CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
+                ),
             },
             headers={"Authorization": f"Bearer {settings.cms_service_token}"},
             timeout=30,

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -843,8 +843,8 @@ class TestMultilingualContent(unittest.TestCase):
 
 
 class FetchAssembledTestParamsTests(unittest.TestCase):
-    """curriculum_id/grade_id must always be SENT (the CMS 502s without them) even though
-    callers may now omit them — nex-gen-cms shortened its test URLs to `/test?id=<id>`.
+    """A test is identified by its id alone; curriculum_id/grade_id are forwarded only when
+    the caller knows them — nex-gen-cms shortened its test URLs to `/test?id=<id>`.
     """
 
     def _capture_params(self, **kwargs):
@@ -873,19 +873,13 @@ class FetchAssembledTestParamsTests(unittest.TestCase):
         self.assertEqual(params["curriculum_id"], 2)
         self.assertEqual(params["grade_id"], 4)
 
-    def test_substitutes_placeholder_when_omitted(self):
+    def test_omits_curriculum_and_grade_when_not_given(self):
         params = self._capture_params()
-        placeholder = cms_ingest._CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
-        self.assertEqual(params["id"], 504)
-        self.assertEqual(params["curriculum_id"], placeholder)
-        self.assertEqual(params["grade_id"], placeholder)
+        self.assertEqual(params, {"id": 504})
 
-    def test_substitutes_placeholder_for_each_param_independently(self):
+    def test_forwards_only_the_ids_the_caller_knows(self):
         params = self._capture_params(curriculum_id=2)
-        self.assertEqual(params["curriculum_id"], 2)
-        self.assertEqual(
-            params["grade_id"], cms_ingest._CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
-        )
+        self.assertEqual(params, {"id": 504, "curriculum_id": 2})
 
 
 if __name__ == "__main__":

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -6,7 +6,9 @@ No MongoDB needed — these exercise the pure mapping.
 """
 
 import unittest
+from unittest import mock
 
+from services import cms_ingest
 from services.cms_ingest import map_cms_test_to_quiz, CmsIngestError
 
 
@@ -838,6 +840,52 @@ class TestMultilingualContent(unittest.TestCase):
         self.assertEqual(question["correct_answer"], 3)
         self.assertTrue(question["graded"])
         self.assertEqual(warnings, [])
+
+
+class FetchAssembledTestParamsTests(unittest.TestCase):
+    """curriculum_id/grade_id must always be SENT (the CMS 502s without them) even though
+    callers may now omit them — nex-gen-cms shortened its test URLs to `/test?id=<id>`.
+    """
+
+    def _capture_params(self, **kwargs):
+        captured = {}
+
+        class _Response:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"test": {}, "problems": []}
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            captured.update(params or {})
+            return _Response()
+
+        with mock.patch.object(cms_ingest.requests, "get", fake_get), mock.patch.object(
+            cms_ingest.settings, "cms_service_endpoint", "https://cms.example"
+        ), mock.patch.object(cms_ingest.settings, "cms_service_token", "tok"):
+            cms_ingest.fetch_assembled_test(504, **kwargs)
+        return captured
+
+    def test_passes_through_explicit_curriculum_and_grade(self):
+        params = self._capture_params(curriculum_id=2, grade_id=4)
+        self.assertEqual(params["id"], 504)
+        self.assertEqual(params["curriculum_id"], 2)
+        self.assertEqual(params["grade_id"], 4)
+
+    def test_substitutes_placeholder_when_omitted(self):
+        params = self._capture_params()
+        placeholder = cms_ingest._CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
+        self.assertEqual(params["id"], 504)
+        self.assertEqual(params["curriculum_id"], placeholder)
+        self.assertEqual(params["grade_id"], placeholder)
+
+    def test_substitutes_placeholder_for_each_param_independently(self):
+        params = self._capture_params(curriculum_id=2)
+        self.assertEqual(params["curriculum_id"], 2)
+        self.assertEqual(
+            params["grade_id"], cms_ingest._CMS_PLACEHOLDER_CURRICULUM_GRADE_ID
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

nex-gen-cms **#170** shortened its test URLs to `/test?id=<id>`, dropping `curriculum_id`/`grade_id`. `/quiz/from-cms` required all three, so a caller holding only a pasted CMS test link couldn't satisfy the contract:

- **quiz-creator** rejects the URL — *"Please provide a valid legacy or new CMS test URL"* (`isValidCmsUrl` demands all three)
- **sessionCreator** is worse: `parse_new_cms_link` returns `None` when any is missing and `process_row` gates on `if new_cms_ids:` — so the link **silently falls through** to another dispatch branch and the quiz is never built as a CMS test

## Why they aren't needed

A test is identified by its **`id` alone**. Per db-service **#651**: *"every problem can have exactly one `resource_curriculum` row, hence filtering is not required on `curriculum_id`"* — so curriculum never selected content.

Confirmed against prod for test 8901, which is tagged to two curriculum-grade pairs (`[{2,4},{1,1}]`):

| Params | problems | sha(problem ids) | marks |
|---|---|---|---|
| `curriculum_id=2&grade_id=4` (real pair) | 180 | `5ef3b3f67679` | 720 |
| `curriculum_id=1&grade_id=1` (its other real pair) | 180 | `5ef3b3f67679` | 720 |
| `curriculum_id=999&grade_id=999` | 180 | same | 720 |

Byte-identical. Multi-curriculum tagging is about where a test is *listed*, not which problems it contains.

## Change

- `CmsQuizIngestRequest.curriculum_id` / `.grade_id` → `Optional[int] = None`
- `fetch_assembled_test` builds its query params from what it was given: `id` always, curriculum/grade only when the caller knows them

Callers that know the real pair keep sending it. **af_lms is unchanged** — it derives both from its own exam-track/grade pickers (`curriculumIdForExamTrack` / `resolveGradeId`) and fails closed if grade won't resolve.

Applies to both `POST /quiz/from-cms` and `PUT /quiz/{id}/from-cms` (shared model + fetch).

## Dependency — satisfied

Until today the CMS 502'd on `/api/service/test?id=<id>` alone (`getTestProblems` forwarded the empty param into db-service, which did `String.to_integer("")`). db-service **#677** fixed that and is deployed to `release`; re-verified against prod just now — `?id=8901` alone returns **200 with all 180 problems**. So this PR needs no placeholder or workaround.

## Tests

3 new cases in `test_cms_ingest.py`: explicit pair passes through; both omitted → only `id` is sent; partial → only what was given is sent. 26 passed; `black` clean.

## Follow-ups

- **etl-data-flow** `fix/cms-short-link-parse` — sessionCreator accepts an id-only link (pushed)
- **quiz-creator** `fix/accept-short-cms-test-url` — relax `isValidCmsUrl` (ready)
- **nex-gen-cms** — `getTestProblems` calls `http.Error` without `return`, then nil-derefs in `fillProblemSubjects`; worth guarding independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
