### PR TITLE
Prod: make curriculum_id/grade_id optional on /quiz/from-cms (cherry-pick of #174)

### DIFF
--- a/app/routers/quizzes.py
+++ b/app/routers/quizzes.py
@@ -192,8 +192,10 @@ class CmsQuizIngestRequest(BaseModel):
     """
 
     test_id: int
-    curriculum_id: int
-    grade_id: int
+    # Optional: the CMS identifies a test by `id` alone and ignores these values. Callers
+    # holding only a shortened CMS link (`/test?id=<id>`) can omit them.
+    curriculum_id: Optional[int] = None
+    grade_id: Optional[int] = None
     quiz_type: str = QuizType.assessment.value
     # Raw session window-end as an ISO wall-clock string (IST), e.g. "2026-04-15T14:00:00".
     # The stored metadata.session_end_time is this PLUS the quiz duration (see

--- a/app/services/cms_ingest.py
+++ b/app/services/cms_ingest.py
@@ -90,23 +90,31 @@ class CmsIngestError(Exception):
 
 
 def fetch_assembled_test(
-    test_id: int, curriculum_id: int, grade_id: int
+    test_id: int,
+    curriculum_id: Optional[int] = None,
+    grade_id: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Fetch the assembled-test JSON from the new CMS. Raises CmsIngestError on failure."""
+    """Fetch the assembled-test JSON from the new CMS. Raises CmsIngestError on failure.
+
+    A test is identified by its id alone; curriculum_id/grade_id are optional and only
+    forwarded when the caller knows them.
+    """
     if not settings.cms_service_endpoint or not settings.cms_service_token:
         raise CmsIngestError(
             "CMS_SERVICE_ENDPOINT / CMS_SERVICE_TOKEN are not configured"
         )
 
+    params = {"id": test_id}
+    if curriculum_id is not None:
+        params["curriculum_id"] = curriculum_id
+    if grade_id is not None:
+        params["grade_id"] = grade_id
+
     url = settings.cms_service_endpoint.rstrip("/") + "/api/service/test"
     try:
         response = requests.get(
             url,
-            params={
-                "id": test_id,
-                "curriculum_id": curriculum_id,
-                "grade_id": grade_id,
-            },
+            params=params,
             headers={"Authorization": f"Bearer {settings.cms_service_token}"},
             timeout=30,
         )

--- a/app/tests/test_cms_ingest.py
+++ b/app/tests/test_cms_ingest.py
@@ -6,7 +6,9 @@ No MongoDB needed — these exercise the pure mapping.
 """
 
 import unittest
+from unittest import mock
 
+from services import cms_ingest
 from services.cms_ingest import map_cms_test_to_quiz, CmsIngestError
 
 
@@ -838,6 +840,46 @@ class TestMultilingualContent(unittest.TestCase):
         self.assertEqual(question["correct_answer"], 3)
         self.assertTrue(question["graded"])
         self.assertEqual(warnings, [])
+
+
+class FetchAssembledTestParamsTests(unittest.TestCase):
+    """A test is identified by its id alone; curriculum_id/grade_id are forwarded only when
+    the caller knows them — nex-gen-cms shortened its test URLs to `/test?id=<id>`.
+    """
+
+    def _capture_params(self, **kwargs):
+        captured = {}
+
+        class _Response:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"test": {}, "problems": []}
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            captured.update(params or {})
+            return _Response()
+
+        with mock.patch.object(cms_ingest.requests, "get", fake_get), mock.patch.object(
+            cms_ingest.settings, "cms_service_endpoint", "https://cms.example"
+        ), mock.patch.object(cms_ingest.settings, "cms_service_token", "tok"):
+            cms_ingest.fetch_assembled_test(504, **kwargs)
+        return captured
+
+    def test_passes_through_explicit_curriculum_and_grade(self):
+        params = self._capture_params(curriculum_id=2, grade_id=4)
+        self.assertEqual(params["id"], 504)
+        self.assertEqual(params["curriculum_id"], 2)
+        self.assertEqual(params["grade_id"], 4)
+
+    def test_omits_curriculum_and_grade_when_not_given(self):
+        params = self._capture_params()
+        self.assertEqual(params, {"id": 504})
+
+    def test_forwards_only_the_ids_the_caller_knows(self):
+        params = self._capture_params(curriculum_id=2)
+        self.assertEqual(params, {"id": 504, "curriculum_id": 2})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cherry-pick of **#174** onto `release` so the CMS fix can reach prod on its own.

## Why not promote `main` → `release`

`main` is currently **55 commits** ahead of `release`. Promoting would also ship:

- **#140 — Python 3.12 + Pydantic v2 upgrade** (~20 commits: BaseSettings swap, ConfigDict conversion, PyObjectId rewrite, Dockerfile + CI, Mangum/Lambda removal). Merged today with **5 COMMENTED reviews and 0 approvals**. Pydantic v2 changes validation behaviour at runtime — that deserves its own deliberate deploy with someone watching.
- **#139 — batch-update optimization** (~10 commits, incl. an off-by-one fix in the session_answers read path).

Neither should ride to prod on the back of a 61-line CMS fix.

## What this contains

Exactly #174's net diff, as one commit — 3 files, +61/−9:

- `CmsQuizIngestRequest.curriculum_id` / `.grade_id` → `Optional[int] = None`
- `fetch_assembled_test` forwards them only when the caller knows them (`id` always)
- 3 new tests

`git diff origin/release --stat` confirms only those files change.

## Why the ids aren't needed

Per db-service **#651**: *"every problem can have exactly one `resource_curriculum` row, hence filtering is not required on `curriculum_id`"*. Verified against prod — test 8901 (tagged to two curriculum-grade pairs) returns a byte-identical payload for either real pair or for nonsense values.

This unblocks the shortened CMS test links (`/test?id=<id>`) that nex-gen-cms **#170** now produces, which today are rejected by quiz-creator and — worse — silently dropped by sessionCreator.

## Verification on this branch

- `test_cms_ingest.py`: **26 passed** (against the release codebase, i.e. pre-Pydantic-v2)
- `black --check`: clean
- Dependency satisfied: db-service #677 is merged and on `release`; re-verified against prod that `/api/service/test?id=8901` alone returns 200 with all 180 problems

## Note

The release-only commits were checked: `4b7ee9b` (chapter-metadata hotfix cherry-picked onto release) also exists on main as `75a7db9`, and nothing is removed by this branch — no regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)